### PR TITLE
feat(service): Conclui implementação do FeeCalculationService (#6)

### DIFF
--- a/app/Exceptions/FeeCalculationException.php
+++ b/app/Exceptions/FeeCalculationException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+/**
+ * Custom exception for errors encountered during fee calculation.
+ * This exception will be used by FeeCalculationService to indicate issues
+ * such as missing fee configurations or other calculation problems.
+ */
+class FeeCalculationException extends Exception
+{
+    // Future ACs might add specific properties or methods here if needed.
+}

--- a/app/Services/FeeCalculationService.php
+++ b/app/Services/FeeCalculationService.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Event;
+use App\Models\Fee;
+// Carbon will be needed for AC2, AC4, AC5, uncomment when implementing those.
+// use Carbon\Carbon;
+// A custom Exception could be useful for AC8, uncomment when implementing.
+// use App\Exceptions\FeeCalculationException;
+
+/**
+ * Service class for calculating registration fees.
+ * This service will handle the logic for determining the correct fee
+ * based on participant category, selected events, registration date,
+ * and potential discounts.
+ */
+class FeeCalculationService
+{
+    /**
+     * FeeCalculationService constructor.
+     *
+     * @param \App\Models\Event $eventModel Instance of the Event model.
+     * @param \App\Models\Fee $feeModel Instance of the Fee model.
+     */
+    public function __construct(protected Event $eventModel, protected Fee $feeModel)
+    {
+    }
+
+    // Example of the main method signature, to be implemented in subsequent ACs.
+    //
+    // /**
+    //  * Calculates the total registration fee for a participant.
+    //  *
+    //  * @param string $participantCategory The category of the participant.
+    //  * @param array<string> $eventCodes An array of event codes the participant is registering for.
+    //  * @param \Carbon\Carbon $registrationDate The date of registration.
+    //  * @param bool $isMainConferenceParticipant Indicates if the participant is also registered for the main conference (BCSMIF2025).
+    //  * @return array{details: array<int, array{event_code: string, event_name: string, calculated_price: float}>, total_fee: float}
+    //  * @throws FeeCalculationException If a fee combination is not found.
+    //  */
+    // public function calculateFees(string $participantCategory, array $eventCodes, Carbon $registrationDate, bool $isMainConferenceParticipant = false): array
+    // {
+    //     // Logic for AC2 through AC8 will be implemented here.
+    //     // For AC1, only the class existence is required.
+    //
+    //     // Placeholder return structure for future ACs
+    //     return [
+    //         'details' => [],
+    //         'total_fee' => 0.00,
+    //     ];
+    // }
+}

--- a/app/Services/FeeCalculationService.php
+++ b/app/Services/FeeCalculationService.php
@@ -2,12 +2,10 @@
 
 namespace App\Services;
 
+use App\Exceptions\FeeCalculationException;
 use App\Models\Event;
 use App\Models\Fee;
-// Carbon will be needed for AC2, AC4, AC5, uncomment when implementing those.
-// use Carbon\Carbon;
-// A custom Exception could be useful for AC8, uncomment when implementing.
-// use App\Exceptions\FeeCalculationException;
+use Carbon\Carbon;
 
 /**
  * Service class for calculating registration fees.
@@ -20,34 +18,43 @@ class FeeCalculationService
     /**
      * FeeCalculationService constructor.
      *
-     * @param \App\Models\Event $eventModel Instance of the Event model.
-     * @param \App\Models\Fee $feeModel Instance of the Fee model.
+     * @param  \App\Models\Event  $eventModel  Instance of the Event model.
+     * @param  \App\Models\Fee  $feeModel  Instance of the Fee model.
      */
-    public function __construct(protected Event $eventModel, protected Fee $feeModel)
-    {
-    }
+    public function __construct(protected Event $eventModel, protected Fee $feeModel) {}
 
-    // Example of the main method signature, to be implemented in subsequent ACs.
-    //
-    // /**
-    //  * Calculates the total registration fee for a participant.
-    //  *
-    //  * @param string $participantCategory The category of the participant.
-    //  * @param array<string> $eventCodes An array of event codes the participant is registering for.
-    //  * @param \Carbon\Carbon $registrationDate The date of registration.
-    //  * @param bool $isMainConferenceParticipant Indicates if the participant is also registered for the main conference (BCSMIF2025).
-    //  * @return array{details: array<int, array{event_code: string, event_name: string, calculated_price: float}>, total_fee: float}
-    //  * @throws FeeCalculationException If a fee combination is not found.
-    //  */
-    // public function calculateFees(string $participantCategory, array $eventCodes, Carbon $registrationDate, bool $isMainConferenceParticipant = false): array
-    // {
-    //     // Logic for AC2 through AC8 will be implemented here.
-    //     // For AC1, only the class existence is required.
-    //
-    //     // Placeholder return structure for future ACs
-    //     return [
-    //         'details' => [],
-    //         'total_fee' => 0.00,
-    //     ];
-    // }
+    /**
+     * Calculates the total registration fee for a participant.
+     *
+     * This method forms the basis for calculating fees. Subsequent ACs will
+     * implement the detailed logic for fetching prices, determining early/late
+     * periods, and applying discounts.
+     *
+     * @param  string  $participantCategory  The category of the participant (e.g., 'grad_student').
+     * @param  array<string>  $eventCodes  An array of event codes the participant is registering for (e.g., ['BCSMIF2025', 'RAA2025']).
+     * @param  \Carbon\Carbon  $registrationDate  The date of registration.
+     * @param  bool  $isMainConferenceParticipant  Indicates if the participant is also registered for the main conference (BCSMIF2025),
+     *                                             used for workshop discount logic. Defaults to false.
+     * @return array{
+     *     details: array<int, array{event_code: string, event_name: string, calculated_price: float}>,
+     *     total_fee: float
+     * }
+     * An associative array containing:
+     * - 'details': A list of details for each event, including its code, name, and calculated price.
+     * - 'total_fee': The sum of all calculated prices.
+     *
+     * @throws \App\Exceptions\FeeCalculationException If a fee combination is not found (to be implemented in AC8).
+     */
+    public function calculateFees(string $participantCategory, array $eventCodes, Carbon $registrationDate, bool $isMainConferenceParticipant = false): array
+    {
+        // Logic for AC3 through AC8 will be implemented here.
+        // For AC2, only the method signature and basic structure are required.
+        // The @throws tag for FeeCalculationException is in preparation for AC8.
+
+        // Placeholder return structure for future ACs
+        return [
+            'details' => [],
+            'total_fee' => 0.00,
+        ];
+    }
 }

--- a/app/Services/FeeCalculationService.php
+++ b/app/Services/FeeCalculationService.php
@@ -2,59 +2,142 @@
 
 namespace App\Services;
 
-use App\Exceptions\FeeCalculationException;
 use App\Models\Event;
 use App\Models\Fee;
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Service class for calculating registration fees.
- * This service will handle the logic for determining the correct fee
- * based on participant category, selected events, registration date,
- * and potential discounts.
+ *
+ * This service handles the logic for determining the correct fee based on
+ * participant category, selected events, registration date, and potential discounts.
  */
 class FeeCalculationService
 {
+    protected Event $eventModel;
+
+    protected Fee $feeModel;
+
     /**
      * FeeCalculationService constructor.
-     *
-     * @param  \App\Models\Event  $eventModel  Instance of the Event model.
-     * @param  \App\Models\Fee  $feeModel  Instance of the Fee model.
      */
-    public function __construct(protected Event $eventModel, protected Fee $feeModel) {}
+    public function __construct(Event $eventModel, Fee $feeModel)
+    {
+        $this->eventModel = $eventModel;
+        $this->feeModel = $feeModel;
+    }
 
     /**
      * Calculates the total registration fee for a participant.
      *
-     * This method forms the basis for calculating fees. Subsequent ACs will
-     * implement the detailed logic for fetching prices, determining early/late
-     * periods, and applying discounts.
-     *
-     * @param  string  $participantCategory  The category of the participant (e.g., 'grad_student').
-     * @param  array<string>  $eventCodes  An array of event codes the participant is registering for (e.g., ['BCSMIF2025', 'RAA2025']).
-     * @param  \Carbon\Carbon  $registrationDate  The date of registration.
-     * @param  bool  $isMainConferenceParticipant  Indicates if the participant is also registered for the main conference (BCSMIF2025),
-     *                                             used for workshop discount logic. Defaults to false.
-     * @return array{
-     *     details: array<int, array{event_code: string, event_name: string, calculated_price: float}>,
-     *     total_fee: float
-     * }
-     * An associative array containing:
-     * - 'details': A list of details for each event, including its code, name, and calculated price.
-     * - 'total_fee': The sum of all calculated prices.
-     *
-     * @throws \App\Exceptions\FeeCalculationException If a fee combination is not found (to be implemented in AC8).
+     * @param  string  $participantCategory  The category of the participant (e.g., 'undergrad_student').
+     * @param  list<string>  $eventCodes  An array of event codes the participant is registering for.
+     * @param  \Illuminate\Support\Carbon  $registrationDate  The date of registration.
+     * @param  string  $participationType  The type of participation (e.g., 'in-person', 'online').
+     * @return array{details: list<array{event_code: string, event_name: string, calculated_price: float, error?: string, query_details?: array<string, mixed>, fee_object_retrieved?: array<string, mixed>}>, total_fee: float}
+     *                                                                                                                                                                                                                           An array containing detailed fee breakdown and the total fee.
+     *                                                                                                                                                                                                                           - 'details': An array of arrays, each with 'event_code', 'event_name', and 'calculated_price'.
+     *                                                                                                                                                                                                                           May also include 'error' if an issue occurred for a specific event.
+     *                                                                                                                                                                                                                           - 'total_fee': The sum total of all calculated fees.
      */
-    public function calculateFees(string $participantCategory, array $eventCodes, Carbon $registrationDate, bool $isMainConferenceParticipant = false): array
-    {
-        // Logic for AC3 through AC8 will be implemented here.
-        // For AC2, only the method signature and basic structure are required.
-        // The @throws tag for FeeCalculationException is in preparation for AC8.
+    public function calculateFees(
+        string $participantCategory,
+        array $eventCodes,
+        Carbon $registrationDate,
+        string $participationType = 'in-person'
+    ): array {
+        $feeDetails = [];
+        $totalFee = 0.0;
 
-        // Placeholder return structure for future ACs
+        $mainConferenceCode = config('fee_calculation.main_conference_code', 'BCSMIF2025');
+        $isAttendingMainConference = in_array($mainConferenceCode, $eventCodes);
+
+        foreach ($eventCodes as $eventCode) {
+            $event = $this->eventModel->where('code', $eventCode)->first();
+
+            if (! $event) {
+                Log::warning("FeeCalculationService: Event not found for code {$eventCode}.");
+                $feeDetails[] = [
+                    'event_code' => $eventCode,
+                    'event_name' => __('fees.event_not_found'),
+                    'calculated_price' => 0.00,
+                    'error' => __('fees.event_not_found'),
+                ];
+
+                continue;
+            }
+
+            // Determine period based on registration date and event's early deadline (AC4 & AC5 logic placeholder)
+            // For AC3, this logic is simplified but present to allow fee fetching.
+            $period = ($event->registration_deadline_early && $registrationDate->lte($event->registration_deadline_early))
+                ? 'early'
+                : 'late';
+
+            $feeQuery = $this->feeModel
+                ->where('event_code', $eventCode)
+                ->where('participant_category', $participantCategory)
+                ->where('type', $participationType)
+                ->where('period', $period);
+
+            $foundFee = null;
+
+            // Discount logic for workshops if attending main conference (AC6 logic placeholder for fetching)
+            if (! $event->is_main_conference && $isAttendingMainConference) {
+                $feeWithDiscount = (clone $feeQuery)->where('is_discount_for_main_event_participant', true)->first();
+                if ($feeWithDiscount) {
+                    $foundFee = $feeWithDiscount;
+                }
+            }
+
+            if (! $foundFee) {
+                // Fetch standard fee (or workshop fee if not discounted, or main conference fee)
+                $feeWithoutDiscount = (clone $feeQuery)->where('is_discount_for_main_event_participant', false)->first();
+                if ($feeWithoutDiscount) {
+                    $foundFee = $feeWithoutDiscount;
+                }
+            }
+
+            if ($foundFee) {
+                $calculatedPrice = (float) $foundFee->price; // Fee model casts price to string, so cast back.
+                $totalFee += $calculatedPrice;
+                $feeDetails[] = [
+                    'event_code' => $eventCode,
+                    'event_name' => $event->name,
+                    'calculated_price' => $calculatedPrice,
+                    // 'fee_object_retrieved' => $foundFee->toArray(), // Useful for debugging AC3
+                ];
+            } else {
+                Log::warning('FeeCalculationService: Fee configuration not found.', [
+                    'event_code' => $eventCode,
+                    'participant_category' => $participantCategory,
+                    'type' => $participationType,
+                    'period' => $period,
+                    'is_main_conference_event' => $event->is_main_conference,
+                    'is_attending_main_conference' => $isAttendingMainConference,
+                ]);
+                $feeDetails[] = [
+                    'event_code' => $eventCode,
+                    'event_name' => $event->name,
+                    'calculated_price' => 0.00,
+                    'error' => __('fees.fee_config_not_found'),
+                    /*
+                    'query_details' => [ // Useful for debugging AC3
+                        'event_code' => $eventCode,
+                        'participant_category' => $participantCategory,
+                        'type' => $participationType,
+                        'period' => $period,
+                        'is_main_conference_event' => $event->is_main_conference,
+                        'is_attending_main_conference' => $isAttendingMainConference,
+                    ]
+                    */
+                ];
+            }
+        }
+
         return [
-            'details' => [],
-            'total_fee' => 0.00,
+            'details' => $feeDetails,
+            'total_fee' => $totalFee,
         ];
     }
 }

--- a/config/fee_calculation.php
+++ b/config/fee_calculation.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Main Conference Event Code
+    |--------------------------------------------------------------------------
+    |
+    | This value specifies the unique code used to identify the main conference
+    | event. It is used by the FeeCalculationService to determine if a
+    | participant is attending the main conference, which may affect
+    | pricing for associated workshops or satellite events.
+    |
+    */
+    'main_conference_code' => env('MAIN_CONFERENCE_CODE', 'BCSMIF2025'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Participation Type
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the default participation type (e.g., 'in-person', 'online')
+    | to be used by the FeeCalculationService if no specific type is provided
+    | during a fee calculation request.
+    |
+    */
+    'default_participation_type' => 'in-person',
+];

--- a/lang/en.json
+++ b/lang/en.json
@@ -79,6 +79,8 @@
     "Export": "Export",
     "Export :name": "Export :name",
     "Failed Dependency": "Failed Dependency",
+    "fees.event_not_found": "Event not found",
+    "fees.fee_config_not_found": "Fee configuration not found for this combination.",
     "File": "File",
     "Files": "Files",
     "Forbidden": "Forbidden",

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -81,6 +81,8 @@
     "Export": "Exportar",
     "Export :name": "Exportar :name",
     "Failed Dependency": "Dependência Com Falha",
+    "fees.event_not_found": "Evento não encontrado",
+    "fees.fee_config_not_found": "Configuração de taxa não encontrada para esta combinação.",
     "File": "Arquivo",
     "Files": "arquivos",
     "Forbidden": "Proibido",

--- a/scripts/llm_core/config.py
+++ b/scripts/llm_core/config.py
@@ -102,6 +102,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "context_llm/code/{latest_dir_name}/phpunit_test_results.txt",  # Opcional, pode não existir
             "context_llm/code/{latest_dir_name}/phpstan_analysis.txt",  # Opcional
             "context_llm/code/{latest_dir_name}/dusk_test_results.txt",  # Opcional
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/descricao_evento.md",
             "docs/formulario_inscricao.md",
         ],
@@ -114,6 +115,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
             "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/git_log.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
             "docs/descricao_evento.md",
@@ -127,6 +129,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
         "static": [
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
             "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
             "docs/descricao_evento.md",
@@ -139,6 +142,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
         },
         "static": [
             "context_llm/code/{latest_dir_name}/git_log.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
             "docs/descricao_evento.md",
@@ -158,6 +162,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "CHANGELOG.md",
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",  # Diff da issue
             "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
         ],
     },
     "fix-artisan-test": {
@@ -165,6 +170,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
             "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/phpunit_test_results.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/padroes_codigo_boas_praticas.md",
         ]
     },
@@ -173,6 +179,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
             "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/dusk_test_results.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/padroes_codigo_boas_praticas.md",
         ]
     },
@@ -181,6 +188,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
             "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/phpstan_analysis.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/padroes_codigo_boas_praticas.md",
         ]
     },
@@ -192,6 +200,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
         "static": [
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
             "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
             ".github/workflows/laravel.yml",
@@ -207,6 +216,7 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "docs/padroes_codigo_boas_praticas.md",
             "context_llm/code/{latest_dir_name}/git_log.txt",
             "context_llm/code/{latest_dir_name}/gh_pr_list.txt",
+            "context_llm/code/{latest_dir_name}/project_tree_L3.txt",
             "docs/descricao_evento.md",
             "docs/formulario_inscricao.md",
         ],

--- a/scripts/llm_core/config.py
+++ b/scripts/llm_core/config.py
@@ -97,6 +97,8 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
         "static": [
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
+            "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
+            "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/phpunit_test_results.txt",  # Opcional, pode não existir
             "context_llm/code/{latest_dir_name}/phpstan_analysis.txt",  # Opcional
             "context_llm/code/{latest_dir_name}/dusk_test_results.txt",  # Opcional
@@ -110,9 +112,12 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
         },
         "static": [
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
+            "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/git_log.txt",
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
+            "docs/descricao_evento.md",
+            "docs/formulario_inscricao.md",
         ],
     },
     "analyze-ac": {
@@ -120,8 +125,12 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "issue": "context_llm/code/{latest_dir_name}/github_issue_{issue}_details.json",
         },
         "static": [
+            "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
+            "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
+            "docs/descricao_evento.md",
+            "docs/formulario_inscricao.md",
         ],
     },
     "create-pr": {
@@ -129,10 +138,11 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "issue": "context_llm/code/{latest_dir_name}/github_issue_{issue}_details.json",
         },
         "static": [
-            "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
             "context_llm/code/{latest_dir_name}/git_log.txt",
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
+            "docs/descricao_evento.md",
+            "docs/formulario_inscricao.md",
         ],
     },
     "update-doc": {
@@ -143,24 +153,33 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
         "static": [
             "docs/versionamento_documentacao.md",
             "docs/padroes_codigo_boas_praticas.md",
+            "docs/descricao_evento.md",
+            "docs/formulario_inscricao.md",
             "CHANGELOG.md",
             "context_llm/code/{latest_dir_name}/git_diff_cached.txt",  # Diff da issue
+            "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
         ],
     },
     "fix-artisan-test": {
         "static": [
+            "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
+            "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/phpunit_test_results.txt",
             "docs/padroes_codigo_boas_praticas.md",
         ]
     },
     "fix-artisan-dusk": {
         "static": [
+            "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
+            "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/dusk_test_results.txt",
             "docs/padroes_codigo_boas_praticas.md",
         ]
     },
     "fix-phpstan": {
         "static": [
+            "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
+            "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "context_llm/code/{latest_dir_name}/phpstan_analysis.txt",
             "docs/padroes_codigo_boas_praticas.md",
         ]
@@ -171,9 +190,11 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "issue": "context_llm/code/{latest_dir_name}/github_issue_{issue}_details.json",
         },
         "static": [
+            "context_llm/code/{latest_dir_name}/git_diff_cached.txt",
+            "context_llm/code/{latest_dir_name}/git_diff_unstaged.txt",
             "docs/guia_de_desenvolvimento.md",
             "docs/padroes_codigo_boas_praticas.md",
-            ".github/workflows/laravel.yml",  # Opcional
+            ".github/workflows/laravel.yml",
         ],
     },
     "review-issue": {
@@ -186,7 +207,8 @@ ESSENTIAL_FILES_MAP: Dict[str, Dict[str, Any]] = {
             "docs/padroes_codigo_boas_praticas.md",
             "context_llm/code/{latest_dir_name}/git_log.txt",
             "context_llm/code/{latest_dir_name}/gh_pr_list.txt",
-            "context_llm/code/{latest_dir_name}/20250529_085817_manifest.json",  # Exemplo, precisa ser dinâmico se for usado assim
+            "docs/descricao_evento.md",
+            "docs/formulario_inscricao.md",
         ],
     },
 }

--- a/tests/Unit/Services/FeeCalculationServiceTest.php
+++ b/tests/Unit/Services/FeeCalculationServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Event;
+use App\Models\Fee;
+use App\Services\FeeCalculationService;
+use Mockery;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase as LaravelTestCase; // Use Laravel's TestCase for better integration and mocking capabilities
+
+/**
+ * Unit tests for the FeeCalculationService.
+ */
+#[CoversClass(FeeCalculationService::class)]
+class FeeCalculationServiceTest extends LaravelTestCase
+{
+    /**
+     * Test that the FeeCalculationService class exists and can be instantiated.
+     * This covers AC1 of Issue #6.
+     * It also ensures that the constructor with its dependencies can be resolved.
+     */
+    #[Test]
+    public function fee_calculation_service_class_exists_and_can_be_instantiated(): void
+    {
+        // Mock the dependencies (Event and Fee models) required by the constructor.
+        // This is good practice for unit testing services, allowing isolation.
+        $eventMock = Mockery::mock(Event::class);
+        $feeMock = Mockery::mock(Fee::class);
+
+        // Attempt to instantiate the service.
+        $service = new FeeCalculationService($eventMock, $feeMock);
+
+        // Assert that the instantiated object is an instance of FeeCalculationService.
+        $this->assertInstanceOf(FeeCalculationService::class, $service);
+    }
+
+    /**
+     * Clean up the testing environment before the next test.
+     * This is important for Mockery to close any mocks.
+     */
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}

--- a/tests/Unit/Services/FeeCalculationServiceTest.php
+++ b/tests/Unit/Services/FeeCalculationServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services;
 use App\Models\Event;
 use App\Models\Fee;
 use App\Services\FeeCalculationService;
+use Carbon\Carbon;
 use Mockery;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -16,6 +17,20 @@ use Tests\TestCase as LaravelTestCase; // Use Laravel's TestCase for better inte
 #[CoversClass(FeeCalculationService::class)]
 class FeeCalculationServiceTest extends LaravelTestCase
 {
+    private Event $eventMock;
+
+    private Fee $feeMock;
+
+    private FeeCalculationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->eventMock = Mockery::mock(Event::class);
+        $this->feeMock = Mockery::mock(Fee::class);
+        $this->service = new FeeCalculationService($this->eventMock, $this->feeMock);
+    }
+
     /**
      * Test that the FeeCalculationService class exists and can be instantiated.
      * This covers AC1 of Issue #6.
@@ -24,16 +39,72 @@ class FeeCalculationServiceTest extends LaravelTestCase
     #[Test]
     public function fee_calculation_service_class_exists_and_can_be_instantiated(): void
     {
-        // Mock the dependencies (Event and Fee models) required by the constructor.
-        // This is good practice for unit testing services, allowing isolation.
-        $eventMock = Mockery::mock(Event::class);
-        $feeMock = Mockery::mock(Fee::class);
+        $this->assertInstanceOf(FeeCalculationService::class, $this->service);
+    }
 
-        // Attempt to instantiate the service.
-        $service = new FeeCalculationService($eventMock, $feeMock);
+    /**
+     * Test that the calculateFees method exists, accepts the correct parameters,
+     * and returns the expected basic structure.
+     * This covers AC2 of Issue #6.
+     */
+    #[Test]
+    public function calculate_fees_method_exists_accepts_parameters_and_returns_expected_structure(): void
+    {
+        $participantCategory = 'grad_student';
+        $eventCodes = ['BCSMIF2025', 'RAA2025'];
+        $registrationDate = Carbon::now();
+        $isMainConferenceParticipant = true;
 
-        // Assert that the instantiated object is an instance of FeeCalculationService.
-        $this->assertInstanceOf(FeeCalculationService::class, $service);
+        // Call the method
+        $result = $this->service->calculateFees(
+            $participantCategory,
+            $eventCodes,
+            $registrationDate,
+            $isMainConferenceParticipant
+        );
+
+        // Assert that the result is an array
+        $this->assertIsArray($result);
+
+        // Assert that the array has the 'details' and 'total_fee' keys
+        $this->assertArrayHasKey('details', $result);
+        $this->assertArrayHasKey('total_fee', $result);
+
+        // Assert the types of the values for these keys
+        $this->assertIsArray($result['details']);
+        $this->assertIsFloat($result['total_fee']);
+
+        // For AC2, we just check the basic structure.
+        // The actual content of 'details' and the value of 'total_fee'
+        // will be tested in subsequent ACs.
+        $this->assertEquals([], $result['details']);
+        $this->assertEquals(0.00, $result['total_fee']);
+    }
+
+    /**
+     * Test calculateFees with default for isMainConferenceParticipant.
+     */
+    #[Test]
+    public function calculate_fees_method_works_with_default_is_main_conference_participant(): void
+    {
+        $participantCategory = 'professor_abe';
+        $eventCodes = ['WDA2025'];
+        $registrationDate = Carbon::parse('2025-07-01');
+
+        // Call the method without the last optional parameter
+        $result = $this->service->calculateFees(
+            $participantCategory,
+            $eventCodes,
+            $registrationDate
+        );
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('details', $result);
+        $this->assertArrayHasKey('total_fee', $result);
+        $this->assertIsArray($result['details']);
+        $this->assertIsFloat($result['total_fee']);
+        $this->assertEquals([], $result['details']);
+        $this->assertEquals(0.00, $result['total_fee']);
     }
 
     /**

--- a/tests/Unit/Services/FeeCalculationServiceTest.php
+++ b/tests/Unit/Services/FeeCalculationServiceTest.php
@@ -5,115 +5,501 @@ namespace Tests\Unit\Services;
 use App\Models\Event;
 use App\Models\Fee;
 use App\Services\FeeCalculationService;
-use Carbon\Carbon;
-use Mockery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
-use Tests\TestCase as LaravelTestCase; // Use Laravel's TestCase for better integration and mocking capabilities
+use Tests\TestCase;
 
-/**
- * Unit tests for the FeeCalculationService.
- */
 #[CoversClass(FeeCalculationService::class)]
-class FeeCalculationServiceTest extends LaravelTestCase
+#[Group('service')]
+#[Group('fee-calculation')]
+class FeeCalculationServiceTest extends TestCase
 {
-    private Event $eventMock;
-
-    private Fee $feeMock;
+    use RefreshDatabase;
 
     private FeeCalculationService $service;
+
+    private string $mainConferenceCode;
+
+    private string $workshopCode;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->eventMock = Mockery::mock(Event::class);
-        $this->feeMock = Mockery::mock(Fee::class);
-        $this->service = new FeeCalculationService($this->eventMock, $this->feeMock);
+        $this->service = $this->app->make(FeeCalculationService::class);
+
+        // Seed basic events and fees
+        $this->mainConferenceCode = config('fee_calculation.main_conference_code', 'BCSMIF2025');
+        $this->workshopCode = 'RAA2025'; // Example workshop code
+
+        Event::factory()->create([
+            'code' => $this->mainConferenceCode,
+            'name' => 'Main Conference Event',
+            'is_main_conference' => true,
+            'registration_deadline_early' => Carbon::parse('2025-08-15'),
+        ]);
+        Event::factory()->create([
+            'code' => $this->workshopCode,
+            'name' => 'Workshop Event',
+            'is_main_conference' => false,
+            'registration_deadline_early' => Carbon::parse('2025-08-15'),
+        ]);
+        Event::factory()->create([
+            'code' => 'OTHERCONF',
+            'name' => 'Other Conference',
+            'is_main_conference' => true, // Example of another main event, if structure allows
+            'registration_deadline_early' => Carbon::parse('2025-07-01'),
+        ]);
     }
 
-    /**
-     * Test that the FeeCalculationService class exists and can be instantiated.
-     * This covers AC1 of Issue #6.
-     * It also ensures that the constructor with its dependencies can be resolved.
-     */
     #[Test]
     public function fee_calculation_service_class_exists_and_can_be_instantiated(): void
     {
         $this->assertInstanceOf(FeeCalculationService::class, $this->service);
     }
 
-    /**
-     * Test that the calculateFees method exists, accepts the correct parameters,
-     * and returns the expected basic structure.
-     * This covers AC2 of Issue #6.
-     */
     #[Test]
     public function calculate_fees_method_exists_accepts_parameters_and_returns_expected_structure(): void
     {
-        $participantCategory = 'grad_student';
-        $eventCodes = ['BCSMIF2025', 'RAA2025'];
-        $registrationDate = Carbon::now();
-        $isMainConferenceParticipant = true;
-
-        // Call the method
         $result = $this->service->calculateFees(
-            $participantCategory,
-            $eventCodes,
-            $registrationDate,
-            $isMainConferenceParticipant
+            'grad_student',
+            [$this->mainConferenceCode],
+            Carbon::parse('2025-08-01'),
+            'in-person'
         );
 
-        // Assert that the result is an array
         $this->assertIsArray($result);
-
-        // Assert that the array has the 'details' and 'total_fee' keys
         $this->assertArrayHasKey('details', $result);
         $this->assertArrayHasKey('total_fee', $result);
-
-        // Assert the types of the values for these keys
         $this->assertIsArray($result['details']);
         $this->assertIsFloat($result['total_fee']);
-
-        // For AC2, we just check the basic structure.
-        // The actual content of 'details' and the value of 'total_fee'
-        // will be tested in subsequent ACs.
-        $this->assertEquals([], $result['details']);
-        $this->assertEquals(0.00, $result['total_fee']);
     }
 
-    /**
-     * Test calculateFees with default for isMainConferenceParticipant.
-     */
     #[Test]
-    public function calculate_fees_method_works_with_default_is_main_conference_participant(): void
+    public function calculate_fees_method_works_with_default_participation_type(): void
     {
-        $participantCategory = 'professor_abe';
-        $eventCodes = ['WDA2025'];
-        $registrationDate = Carbon::parse('2025-07-01');
+        // This test relies on 'in-person' being the default, if not, it might need adjustment
+        // For AC3, this is mostly a placeholder to ensure the method structure holds
+        $defaultParticipationType = config('fee_calculation.default_participation_type', 'in-person');
 
-        // Call the method without the last optional parameter
+        Fee::factory()->create([
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'grad_student',
+            'type' => $defaultParticipationType,
+            'period' => 'early',
+            'price' => 100.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
         $result = $this->service->calculateFees(
-            $participantCategory,
-            $eventCodes,
-            $registrationDate
+            'grad_student',
+            [$this->mainConferenceCode],
+            Carbon::parse('2025-08-01') // Early period
         );
 
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('details', $result);
-        $this->assertArrayHasKey('total_fee', $result);
-        $this->assertIsArray($result['details']);
-        $this->assertIsFloat($result['total_fee']);
-        $this->assertEquals([], $result['details']);
+        $this->assertEquals(100.00, $result['total_fee']);
+        $this->assertEquals($this->mainConferenceCode, $result['details'][0]['event_code']);
+        $this->assertEquals(100.00, $result['details'][0]['calculated_price']);
+    }
+
+    #[Test]
+    public function it_correctly_fetches_event_data(): void
+    {
+        Fee::factory()->create([
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'grad_student',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 150.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'grad_student',
+            [$this->mainConferenceCode],
+            Carbon::parse('2025-08-01'), // Early bird
+            'in-person'
+        );
+
+        $this->assertCount(1, $result['details']);
+        $this->assertEquals('Main Conference Event', $result['details'][0]['event_name']);
+        $this->assertEquals(150.00, $result['details'][0]['calculated_price']);
+    }
+
+    #[Test]
+    public function it_handles_event_not_found(): void
+    {
+        $result = $this->service->calculateFees(
+            'grad_student',
+            ['NONEXISTENT_EVENT'],
+            Carbon::parse('2025-08-01'),
+            'in-person'
+        );
+
+        $this->assertCount(1, $result['details']);
+        $this->assertEquals('NONEXISTENT_EVENT', $result['details'][0]['event_code']);
+        $this->assertEquals(__('fees.event_not_found'), $result['details'][0]['error']);
+        $this->assertEquals(0.00, $result['details'][0]['calculated_price']);
         $this->assertEquals(0.00, $result['total_fee']);
     }
 
-    /**
-     * Clean up the testing environment before the next test.
-     * This is important for Mockery to close any mocks.
-     */
-    protected function tearDown(): void
+    #[Test]
+    public function it_correctly_fetches_fee_for_main_event_early_period(): void
     {
-        Mockery::close();
-        parent::tearDown();
+        Fee::factory()->create([
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 1200.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'professor_abe',
+            [$this->mainConferenceCode],
+            Carbon::parse('2025-08-10'), // Early
+            'in-person'
+        );
+        $this->assertEquals(1200.00, $result['details'][0]['calculated_price']);
+        $this->assertEquals(1200.00, $result['total_fee']);
+    }
+
+    #[Test]
+    public function it_correctly_fetches_fee_for_main_event_late_period(): void
+    {
+        Fee::factory()->create([
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'late',
+            'price' => 1400.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'professor_abe',
+            [$this->mainConferenceCode],
+            Carbon::parse('2025-08-20'), // Late
+            'in-person'
+        );
+        $this->assertEquals(1400.00, $result['details'][0]['calculated_price']);
+        $this->assertEquals(1400.00, $result['total_fee']);
+    }
+
+    #[Test]
+    public function it_handles_fee_not_found_for_event_combination(): void
+    {
+        // Event exists, but no matching fee for this category/type/period
+        $result = $this->service->calculateFees(
+            'non_existent_category',
+            [$this->mainConferenceCode],
+            Carbon::parse('2025-08-01'),
+            'in-person'
+        );
+
+        $this->assertCount(1, $result['details']);
+        $this->assertEquals($this->mainConferenceCode, $result['details'][0]['event_code']);
+        $this->assertEquals(__('fees.fee_config_not_found'), $result['details'][0]['error']);
+        $this->assertEquals(0.00, $result['details'][0]['calculated_price']);
+        $this->assertEquals(0.00, $result['total_fee']);
+    }
+
+    #[Test]
+    public function it_fetches_workshop_fee_with_discount_when_attending_main_conference(): void
+    {
+        Fee::factory()->create([ // Discounted fee
+            'event_code' => $this->workshopCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 100.00,
+            'is_discount_for_main_event_participant' => true,
+        ]);
+        Fee::factory()->create([ // Non-discounted fee (should not be picked)
+            'event_code' => $this->workshopCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 250.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'professor_abe',
+            [$this->mainConferenceCode, $this->workshopCode], // Attending main and workshop
+            Carbon::parse('2025-08-01'), // Early
+            'in-person'
+        );
+
+        $workshopDetail = collect($result['details'])->firstWhere('event_code', $this->workshopCode);
+        $this->assertNotNull($workshopDetail);
+        $this->assertEquals(100.00, $workshopDetail['calculated_price']);
+        $this->assertArrayNotHasKey('error', $workshopDetail);
+    }
+
+    #[Test]
+    public function it_fetches_workshop_normal_fee_when_discounted_not_available_but_attending_main(): void
+    {
+        // ONLY Non-discounted fee exists for workshop
+        Fee::factory()->create([
+            'event_code' => $this->workshopCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 250.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+        // Main conference fee (to make total calculable)
+        Fee::factory()->create([
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 1200.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'professor_abe',
+            [$this->mainConferenceCode, $this->workshopCode], // Attending main and workshop
+            Carbon::parse('2025-08-01'), // Early
+            'in-person'
+        );
+
+        $workshopDetail = collect($result['details'])->firstWhere('event_code', $this->workshopCode);
+        $this->assertNotNull($workshopDetail);
+        $this->assertEquals(250.00, $workshopDetail['calculated_price']);
+        $this->assertArrayNotHasKey('error', $workshopDetail);
+        $this->assertEquals(1200.00 + 250.00, $result['total_fee']);
+    }
+
+    #[Test]
+    public function it_fetches_workshop_normal_fee_when_not_attending_main_conference(): void
+    {
+        Fee::factory()->create([ // Discounted fee (should not be picked)
+            'event_code' => $this->workshopCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 100.00,
+            'is_discount_for_main_event_participant' => true,
+        ]);
+        Fee::factory()->create([ // Non-discounted fee
+            'event_code' => $this->workshopCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 250.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'professor_abe',
+            [$this->workshopCode], // Attending only workshop
+            Carbon::parse('2025-08-01'), // Early
+            'in-person'
+        );
+
+        $workshopDetail = collect($result['details'])->firstWhere('event_code', $this->workshopCode);
+        $this->assertNotNull($workshopDetail);
+        $this->assertEquals(250.00, $workshopDetail['calculated_price']);
+        $this->assertArrayNotHasKey('error', $workshopDetail);
+        $this->assertEquals(250.00, $result['total_fee']);
+    }
+
+    #[Test]
+    public function it_handles_fee_not_found_for_workshop_when_attending_main(): void
+    {
+        // No fees defined for workshop at all
+        Fee::factory()->create([ // Main conference fee
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'professor_abe',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 1200.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'professor_abe',
+            [$this->mainConferenceCode, $this->workshopCode],
+            Carbon::parse('2025-08-01'),
+            'in-person'
+        );
+
+        $workshopDetail = collect($result['details'])->firstWhere('event_code', $this->workshopCode);
+        $this->assertNotNull($workshopDetail);
+        $this->assertEquals(0.00, $workshopDetail['calculated_price']);
+        $this->assertEquals(__('fees.fee_config_not_found'), $workshopDetail['error']);
+        $this->assertEquals(1200.00, $result['total_fee']); // Only main conference fee
+    }
+
+    #[Test]
+    public function it_correctly_calculates_total_for_multiple_events_and_types(): void
+    {
+        // Main conference fee
+        Fee::factory()->create([
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'grad_student',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 600.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+        // Workshop fee (discounted)
+        Fee::factory()->create([
+            'event_code' => $this->workshopCode,
+            'participant_category' => 'grad_student',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 0.00, // grad_student workshop is free if discounted
+            'is_discount_for_main_event_participant' => true,
+        ]);
+        // Workshop fee (normal, if not discounted)
+        Fee::factory()->create([
+            'event_code' => $this->workshopCode,
+            'participant_category' => 'grad_student',
+            'type' => 'in-person',
+            'period' => 'early',
+            'price' => 0.00, // grad_student workshop is free even if not discounted
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'grad_student',
+            [$this->mainConferenceCode, $this->workshopCode],
+            Carbon::parse('2025-08-01'),
+            'in-person'
+        );
+
+        $this->assertCount(2, $result['details']);
+        $mainEventDetail = collect($result['details'])->firstWhere('event_code', $this->mainConferenceCode);
+        $workshopEventDetail = collect($result['details'])->firstWhere('event_code', $this->workshopCode);
+
+        $this->assertEquals(600.00, $mainEventDetail['calculated_price']);
+        $this->assertEquals(0.00, $workshopEventDetail['calculated_price']); // Should pick discounted
+        $this->assertEquals(600.00 + 0.00, $result['total_fee']);
+    }
+
+    #[Test]
+    public function it_correctly_uses_participation_type_online(): void
+    {
+        Fee::factory()->create([
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'grad_student',
+            'type' => 'online', // Online fee
+            'period' => 'early',
+            'price' => 200.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+        Fee::factory()->create([
+            'event_code' => $this->mainConferenceCode,
+            'participant_category' => 'grad_student',
+            'type' => 'in-person', // In-person fee (should not be picked)
+            'period' => 'early',
+            'price' => 600.00,
+            'is_discount_for_main_event_participant' => false,
+        ]);
+
+        $result = $this->service->calculateFees(
+            'grad_student',
+            [$this->mainConferenceCode],
+            Carbon::parse('2025-08-01'),
+            'online' // Requesting online fee
+        );
+        $this->assertEquals(200.00, $result['details'][0]['calculated_price']);
+        $this->assertEquals(200.00, $result['total_fee']);
+    }
+
+    public static function providesEventAndFeeDataScenarios(): array
+    {
+        $mainConferenceCode = config('fee_calculation.main_conference_code', 'BCSMIF2025');
+        $workshopCode = 'RAA2025'; // Must match setUp
+
+        return [
+            'main_event_early' => [
+                'category' => 'grad_student',
+                'events' => [$mainConferenceCode],
+                'date' => '2025-08-01',
+                'type' => 'in-person',
+                'fees_to_create' => [
+                    ['event_code' => $mainConferenceCode, 'participant_category' => 'grad_student', 'type' => 'in-person', 'period' => 'early', 'price' => 600.00, 'is_discount_for_main_event_participant' => false],
+                ],
+                'expected_total' => 600.00,
+                'expected_details_count' => 1,
+                'expected_event_prices' => [$mainConferenceCode => 600.00],
+            ],
+            'workshop_only_late_normal_price' => [
+                'category' => 'professor_abe',
+                'events' => [$workshopCode],
+                'date' => '2025-08-20', // Late
+                'type' => 'online',
+                'fees_to_create' => [
+                    ['event_code' => $workshopCode, 'participant_category' => 'professor_abe', 'type' => 'online', 'period' => 'late', 'price' => 150.00, 'is_discount_for_main_event_participant' => false],
+                    ['event_code' => $workshopCode, 'participant_category' => 'professor_abe', 'type' => 'online', 'period' => 'late', 'price' => 100.00, 'is_discount_for_main_event_participant' => true], // Discounted, should be ignored
+                ],
+                'expected_total' => 150.00,
+                'expected_details_count' => 1,
+                'expected_event_prices' => [$workshopCode => 150.00],
+            ],
+            'main_and_workshop_with_discount' => [
+                'category' => 'professor_non_abe_professional',
+                'events' => [$mainConferenceCode, $workshopCode],
+                'date' => '2025-08-01', // Early
+                'type' => 'in-person',
+                'fees_to_create' => [
+                    ['event_code' => $mainConferenceCode, 'participant_category' => 'professor_non_abe_professional', 'type' => 'in-person', 'period' => 'early', 'price' => 1600.00, 'is_discount_for_main_event_participant' => false],
+                    ['event_code' => $workshopCode, 'participant_category' => 'professor_non_abe_professional', 'type' => 'in-person', 'period' => 'early', 'price' => 500.00, 'is_discount_for_main_event_participant' => true], // Discounted
+                    ['event_code' => $workshopCode, 'participant_category' => 'professor_non_abe_professional', 'type' => 'in-person', 'period' => 'early', 'price' => 700.00, 'is_discount_for_main_event_participant' => false], // Normal
+                ],
+                'expected_total' => 1600.00 + 500.00,
+                'expected_details_count' => 2,
+                'expected_event_prices' => [$mainConferenceCode => 1600.00, $workshopCode => 500.00],
+            ],
+            'main_and_workshop_discount_not_found_uses_normal_workshop_price' => [
+                'category' => 'professor_non_abe_professional',
+                'events' => [$mainConferenceCode, $workshopCode],
+                'date' => '2025-08-01', // Early
+                'type' => 'in-person',
+                'fees_to_create' => [
+                    ['event_code' => $mainConferenceCode, 'participant_category' => 'professor_non_abe_professional', 'type' => 'in-person', 'period' => 'early', 'price' => 1600.00, 'is_discount_for_main_event_participant' => false],
+                    // No discounted fee for workshop
+                    ['event_code' => $workshopCode, 'participant_category' => 'professor_non_abe_professional', 'type' => 'in-person', 'period' => 'early', 'price' => 700.00, 'is_discount_for_main_event_participant' => false], // Normal workshop
+                ],
+                'expected_total' => 1600.00 + 700.00,
+                'expected_details_count' => 2,
+                'expected_event_prices' => [$mainConferenceCode => 1600.00, $workshopCode => 700.00],
+            ],
+            'event_not_found_mixed_with_found_event' => [
+                'category' => 'grad_student',
+                'events' => [$mainConferenceCode, 'EVENT_DOES_NOT_EXIST'],
+                'date' => '2025-08-01',
+                'type' => 'online',
+                'fees_to_create' => [
+                    ['event_code' => $mainConferenceCode, 'participant_category' => 'grad_student', 'type' => 'online', 'period' => 'early', 'price' => 200.00, 'is_discount_for_main_event_participant' => false],
+                ],
+                'expected_total' => 200.00,
+                'expected_details_count' => 2,
+                'expected_event_prices' => [$mainConferenceCode => 200.00, 'EVENT_DOES_NOT_EXIST' => 0.00],
+                'expected_error_for_event' => ['EVENT_DOES_NOT_EXIST' => __('fees.event_not_found')],
+            ],
+            'fee_not_found_mixed_with_found_fee' => [
+                'category' => 'undergrad_student',
+                'events' => [$mainConferenceCode, $workshopCode], // Main event has fee, workshop does not for this category
+                'date' => '2025-08-01',
+                'type' => 'in-person',
+                'fees_to_create' => [
+                    ['event_code' => $mainConferenceCode, 'participant_category' => 'undergrad_student', 'type' => 'in-person', 'period' => 'early', 'price' => 0.00, 'is_discount_for_main_event_participant' => false],
+                    // No fee for workshop for undergrad
+                ],
+                'expected_total' => 0.00,
+                'expected_details_count' => 2,
+                'expected_event_prices' => [$mainConferenceCode => 0.00, $workshopCode => 0.00],
+                'expected_error_for_event' => [$workshopCode => __('fees.fee_config_not_found')],
+            ],
+        ];
     }
 }

--- a/tests/python/test_llm_core_context.py
+++ b/tests/python/test_llm_core_context.py
@@ -631,6 +631,9 @@ def test_get_essential_files_for_task_resolve_ac(tmp_path: Path, monkeypatch):
         f"context_llm/code/{latest_dir}/dusk_test_results.txt",
         "docs/descricao_evento.md",             # Added
         "docs/formulario_inscricao.md",         # Added
+        f"context_llm/code/{latest_dir}/git_diff_cached.txt",
+        f"context_llm/code/{latest_dir}/git_diff_unstaged.txt",
+        f"context_llm/code/{latest_dir}/project_tree_L3.txt",
     }
     assert essential_paths_relative_str == expected_paths_str
 


### PR DESCRIPTION
Este Pull Request finaliza a implementação completa do serviço `FeeCalculationService`, centralizando a lógica de cálculo de taxas de inscrição conforme especificado na Issue #6.

**Propósito:**
O objetivo principal é oferecer um mecanismo robusto, reutilizável e testável para determinar as taxas de inscrição de participantes, considerando diversos fatores como categoria, eventos selecionados, período de inscrição (early/late) e elegibilidade a descontos.

**Principais Alterações:**
*   **Criação e Estrutura (AC1, AC2):** Implementação da classe `App\Services\FeeCalculationService` e do método público `calculateFees` com a assinatura e parâmetros definidos, incluindo injeção de dependências para os modelos `Event` e `Fee`.
*   **Busca de Dados e Determinação de Período (AC3, AC4, AC5):** O serviço agora busca corretamente as taxas das tabelas `fees` e `events`. A lógica de determinação do período 'early' e 'late' foi refinada, garantindo que a data limite do período 'early' seja inclusiva (`<=`) e que eventos sem `registration_deadline_early` configured sejam tratados como período 'late' por padrão.
*   **Lógica de Desconto e Retorno (AC6, AC7):** Adicionada a funcionalidade para aplicar corretamente o desconto em workshops para participantes que também se inscrevem no evento principal. O método `calculateFees` retorna um array estruturado, contendo detalhes por evento e a taxa total calculada.
*   **Tratamento de Erros e Testes Abrangentes (AC8, AC9):** O serviço lida graciosamente com cenários onde um evento ou uma combinação específica de taxa não é encontrada, registrando avisos e retornando um preço de `0.00` e uma mensagem de erro. Testes unitários (PHPUnit) foram expandidos para cobrir detalhadamente todos os cenários de cálculo, incluindo diferentes categorias, tipos de participação, períodos 'early'/'late', aplicação/não aplicação de descontos e tratamento de casos de ausência de dados.
*   **Qualidade de Código e Configuração (AC10, AC11):** O código segue os padrões PSR-12 (Laravel Pint) e passa na análise estática do PHPStan, garantindo a qualidade e manutenibilidade. Além disso, foram adicionadas chaves de tradução relevantes para mensagens de erro de taxas e um arquivo de configuração `config/fee_calculation.php` para gerenciar o código do evento principal.

Closes #6