### PR TITLE
feat(models): Implementa modelo Payment para tabela payments (#44)

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * App\Models\Payment
+ *
+ * @property int $id
+ * @property int $registration_id
+ * @property string $amount
+ * @property string $status
+ * @property string|null $payment_proof_path
+ * @property Carbon|null $payment_date
+ * @property string|null $notes
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read \App\Models\Registration $registration
+ */
+class Payment extends Model
+{
+    /** @use HasFactory<\Database\Factories\PaymentFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'registration_id',
+        'amount',
+        'status',
+        'payment_proof_path',
+        'payment_date',
+        'notes',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'decimal:2',
+            'payment_date' => 'datetime',
+        ];
+    }
+
+    /**
+     * Get the registration that this payment belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Models\Registration, $this>
+     */
+    public function registration(): BelongsTo
+    {
+        return $this->belongsTo(Registration::class);
+    }
+}

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Payment;
+use App\Models\Registration;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Payment>
+ */
+class PaymentFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Payment::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'registration_id' => Registration::factory(),
+            'amount' => $this->faker->randomFloat(2, 0, 2000),
+            'status' => $this->faker->randomElement(['pending', 'paid', 'pending_approval', 'cancelled']),
+            'payment_proof_path' => $this->faker->optional(0.3)->filePath(),
+            'payment_date' => $this->faker->optional(0.5)->dateTimeBetween('-1 month', 'now'),
+            'notes' => $this->faker->optional(0.4)->sentence(),
+        ];
+    }
+
+    /**
+     * Indicate that the payment is pending.
+     */
+    public function pending(): Factory
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'pending',
+            'payment_date' => null,
+            'payment_proof_path' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the payment is paid.
+     */
+    public function paid(): Factory
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'paid',
+            'payment_date' => $this->faker->dateTimeBetween('-1 month', 'now'),
+            'payment_proof_path' => $this->faker->filePath(),
+        ]);
+    }
+
+    /**
+     * Indicate that the payment is pending approval.
+     */
+    public function pendingApproval(): Factory
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'pending_approval',
+            'payment_date' => null,
+            'payment_proof_path' => $this->faker->filePath(),
+        ]);
+    }
+
+    /**
+     * Indicate that the payment is cancelled.
+     */
+    public function cancelled(): Factory
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'cancelled',
+            'payment_date' => null,
+            'payment_proof_path' => null,
+        ]);
+    }
+}

--- a/tests/Unit/Models/PaymentTest.php
+++ b/tests/Unit/Models/PaymentTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Payment;
+use App\Models\Registration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * Unit tests for the Payment model.
+ */
+#[CoversClass(Payment::class)]
+#[Group('model')]
+#[Group('payment-model')]
+class PaymentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function payment_factory_can_create_model_instance(): void
+    {
+        $payment = Payment::factory()->create();
+
+        $this->assertInstanceOf(Payment::class, $payment);
+        $this->assertNotNull($payment->id, 'Payment ID should not be null after creation.');
+        $this->assertNotNull($payment->registration_id, 'registration_id should be filled by the factory.');
+        $this->assertNotNull($payment->amount, 'amount should be filled by the factory.');
+        $this->assertNotNull($payment->status, 'status should be filled by the factory.');
+    }
+
+    #[Test]
+    public function amount_is_casted_to_decimal_string(): void
+    {
+        $payment = Payment::factory()->create(['amount' => 123.45]);
+        $this->assertIsString($payment->amount);
+        $this->assertEquals('123.45', $payment->amount);
+
+        $paymentInteger = Payment::factory()->create(['amount' => 100]);
+        $this->assertIsString($paymentInteger->amount);
+        $this->assertEquals('100.00', $paymentInteger->amount);
+
+        $paymentZero = Payment::factory()->create(['amount' => 0]);
+        $this->assertIsString($paymentZero->amount);
+        $this->assertEquals('0.00', $paymentZero->amount);
+    }
+
+    #[Test]
+    public function payment_date_is_casted_to_carbon_instance_or_null(): void
+    {
+        $dateTime = now();
+        $paymentWithDate = Payment::factory()->create(['payment_date' => $dateTime]);
+        $this->assertInstanceOf(Carbon::class, $paymentWithDate->payment_date);
+        $this->assertEquals($dateTime->toDateTimeString(), $paymentWithDate->payment_date->toDateTimeString());
+
+        $paymentNullDate = Payment::factory()->create(['payment_date' => null]);
+        $this->assertNull($paymentNullDate->payment_date);
+    }
+
+    #[Test]
+    public function payment_belongs_to_a_registration(): void
+    {
+        $registration = Registration::factory()->create();
+        $payment = Payment::factory()->create(['registration_id' => $registration->id]);
+
+        $this->assertInstanceOf(Registration::class, $payment->registration);
+        $this->assertEquals($registration->id, $payment->registration->id);
+    }
+
+    #[Test]
+    public function all_fillable_attributes_can_be_mass_assigned(): void
+    {
+        $registration = Registration::factory()->create();
+        $fillableAttributes = (new Payment)->getFillable();
+        $testData = Payment::factory()->make(['registration_id' => $registration->id])->toArray();
+
+        // Remove attributes not in $fillable or handled by DB (id, timestamps)
+        unset($testData['id'], $testData['created_at'], $testData['updated_at']);
+
+        // Ensure all keys in testData are in fillable
+        $validatedData = array_intersect_key($testData, array_flip($fillableAttributes));
+
+        $payment = Payment::create($validatedData);
+        $this->assertNotNull($payment->id);
+
+        foreach ($validatedData as $key => $value) {
+            if (($payment->getCasts()[$key] ?? null) === 'datetime') {
+                if ($value === null) {
+                    $this->assertNull($payment->{$key});
+                } else {
+                    $this->assertInstanceOf(Carbon::class, $payment->{$key}, "Attribute {$key} should be Carbon instance.");
+                    $this->assertEquals(Carbon::parse($value)->toDateTimeString(), $payment->{$key}->toDateTimeString());
+                }
+            } elseif ($key === 'amount') {
+                $this->assertEquals(number_format((float) $value, 2, '.', ''), $payment->{$key});
+            } else {
+                $this->assertEquals($value, $payment->{$key});
+            }
+        }
+    }
+
+    #[Test]
+    public function payment_status_can_be_set_to_valid_values(): void
+    {
+        $validStatuses = ['pending', 'paid', 'pending_approval', 'cancelled'];
+
+        foreach ($validStatuses as $status) {
+            $payment = Payment::factory()->create(['status' => $status]);
+            $this->assertEquals($status, $payment->status);
+        }
+    }
+
+    #[Test]
+    public function payment_proof_path_can_be_null_or_string(): void
+    {
+        $paymentWithProof = Payment::factory()->create(['payment_proof_path' => 'uploads/payments/proof.pdf']);
+        $this->assertEquals('uploads/payments/proof.pdf', $paymentWithProof->payment_proof_path);
+
+        $paymentWithoutProof = Payment::factory()->create(['payment_proof_path' => null]);
+        $this->assertNull($paymentWithoutProof->payment_proof_path);
+    }
+
+    #[Test]
+    public function notes_can_be_null_or_string(): void
+    {
+        $paymentWithNotes = Payment::factory()->create(['notes' => 'Payment confirmed by admin']);
+        $this->assertEquals('Payment confirmed by admin', $paymentWithNotes->notes);
+
+        $paymentWithoutNotes = Payment::factory()->create(['notes' => null]);
+        $this->assertNull($paymentWithoutNotes->notes);
+    }
+}


### PR DESCRIPTION
## Summary

Implementa o modelo Eloquent Payment para interagir com a tabela payments de forma orientada a objetos, conforme especificado na issue #44.

- ✅ AC1: Arquivo `app/Models/Payment.php` criado com classe Payment
- ✅ AC2: Propriedade `$fillable` definida com todos campos da tabela
- ✅ AC3: Propriedade `$casts` configurada (amount: decimal:2, payment_date: datetime)
- ✅ AC4: Relacionamento `registration()` implementado com `BelongsTo(Registration::class)`
- ✅ AC5: PaymentFactory básica criada em `database/factories`
- ✅ AC6: Testes automatizados criados para cobrir a funcionalidade
- ✅ AC7: Todos os testes passam (existentes e novos)
- ✅ AC8: Código segue padrões PSR-12 (formatado com pint)
- ✅ AC9: Código passa na análise estática (phpstan)

## Test plan

- [x] Executar testes unitários: `php artisan test tests/Unit/Models/PaymentTest.php`
- [x] Executar testes de migração: `php artisan test tests/Unit/Database/CreatePaymentsTableMigrationTest.php`
- [x] Verificar quality checks: `vendor/bin/pint && vendor/bin/phpstan analyse`
- [x] Executar todos os testes: `php artisan test`
- [x] Validar ACs com analyze-ac para AC1, AC2, AC3, AC4, AC5, AC6