### PR TITLE
feat(form): Atualiza e internacionaliza a lista de países

### DIFF
--- a/config/countries.php
+++ b/config/countries.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Countries List
+    |--------------------------------------------------------------------------
+    |
+    | This configuration contains the list of countries for the registration form.
+    | The array is ordered alphabetically by English name.
+    | The key is the English name (stored in database),
+    | and the value is the English name for reference.
+    |
+    */
+
+    'countries' => [
+        'Azerbaijan' => 'Azerbaijan',
+        'Belgium' => 'Belgium',
+        'Brazil' => 'Brazil',
+        'Canada' => 'Canada',
+        'Chile' => 'Chile',
+        'France' => 'France',
+        'Germany' => 'Germany',
+        'Greece' => 'Greece',
+        'Italy' => 'Italy',
+        'Portugal' => 'Portugal',
+        'United Arab Emirates' => 'United Arab Emirates',
+        'United Kingdom' => 'United Kingdom',
+        'United States' => 'United States',
+        'Other' => 'Other',
+    ],
+];

--- a/lang/en/countries.php
+++ b/lang/en/countries.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'Azerbaijan' => 'Azerbaijan',
+    'Belgium' => 'Belgium',
+    'Brazil' => 'Brazil',
+    'Canada' => 'Canada',
+    'Chile' => 'Chile',
+    'France' => 'France',
+    'Germany' => 'Germany',
+    'Greece' => 'Greece',
+    'Italy' => 'Italy',
+    'Portugal' => 'Portugal',
+    'United Arab Emirates' => 'United Arab Emirates',
+    'United Kingdom' => 'United Kingdom',
+    'United States' => 'United States',
+    'Other' => 'Other',
+];

--- a/lang/pt_BR/countries.php
+++ b/lang/pt_BR/countries.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+    'Azerbaijan' => 'Azerbaijão',
+    'Belgium' => 'Bélgica',
+    'Brazil' => 'Brasil',
+    'Canada' => 'Canadá',
+    'Chile' => 'Chile',
+    'France' => 'França',
+    'Germany' => 'Alemanha',
+    'Greece' => 'Grécia',
+    'Italy' => 'Itália',
+    'Portugal' => 'Portugal',
+    'United Arab Emirates' => 'Emirados Árabes Unidos',
+    'United Kingdom' => 'Reino Unido',
+    'United States' => 'Estados Unidos',
+    'Other' => 'Outro',
+];

--- a/resources/views/livewire/registration-form.blade.php
+++ b/resources/views/livewire/registration-form.blade.php
@@ -83,15 +83,15 @@ new #[Layout('layouts.app')] class extends Component {
         // Load available events
         $this->available_events = Event::all()->pluck('name', 'code')->toArray();
         
-        // Load countries from config with bilingual display
+        // Load countries from config using Laravel localization
         $countries = config('countries.countries');
         $this->countries = [];
         
         foreach ($countries as $englishName => $displayName) {
             if ($englishName === 'Other') {
-                $this->countries['OTHER'] = __('countries.' . $englishName) . ' / ' . $englishName;
+                $this->countries['OTHER'] = __('countries.' . $englishName);
             } else {
-                $this->countries[$englishName] = __('countries.' . $englishName) . ' / ' . $englishName;
+                $this->countries[$englishName] = __('countries.' . $englishName);
             }
         }
 

--- a/resources/views/livewire/registration-form.blade.php
+++ b/resources/views/livewire/registration-form.blade.php
@@ -17,7 +17,7 @@ new #[Layout('layouts.app')] class extends Component {
     public string $other_gender = '';
 
     // Identification Details
-    public string $document_country_origin = 'BR';
+    public string $document_country_origin = 'Brazil';
     public string $other_document_country_origin = '';
     public string $cpf = '';
     public string $rg_number = '';
@@ -30,7 +30,7 @@ new #[Layout('layouts.app')] class extends Component {
     public string $address_street = '';
     public string $address_city = '';
     public string $address_state_province = '';
-    public string $address_country = 'BR';
+    public string $address_country = 'Brazil';
     public string $other_address_country = '';
     public string $address_postal_code = '';
 
@@ -83,20 +83,17 @@ new #[Layout('layouts.app')] class extends Component {
         // Load available events
         $this->available_events = Event::all()->pluck('name', 'code')->toArray();
         
-        // Load countries (simplified list for now)
-        $this->countries = [
-            'AR' => __('Argentina'),
-            'BR' => __('Brazil'),
-            'CA' => __('Canada'),
-            'CL' => __('Chile'),
-            'CO' => __('Colombia'),
-            'US' => __('United States'),
-            'MX' => __('Mexico'),
-            'PE' => __('Peru'),
-            'UY' => __('Uruguay'),
-            'VE' => __('Venezuela'),
-            'OTHER' => __('Other'),
-        ];
+        // Load countries from config with bilingual display
+        $countries = config('countries.countries');
+        $this->countries = [];
+        
+        foreach ($countries as $englishName => $displayName) {
+            if ($englishName === 'Other') {
+                $this->countries['OTHER'] = __('countries.' . $englishName) . ' / ' . $englishName;
+            } else {
+                $this->countries[$englishName] = __('countries.' . $englishName) . ' / ' . $englishName;
+            }
+        }
 
         // Pre-fill email if user is logged in
         if (auth()->user()) {
@@ -178,10 +175,10 @@ new #[Layout('layouts.app')] class extends Component {
             'gender' => 'required|string|in:male,female,other,prefer_not_to_say',
             'other_gender' => 'required_if:gender,other|string|max:255',
             'document_country_origin' => 'required|string',
-            'cpf' => 'required_if:document_country_origin,BR|nullable|string|max:20',
-            'rg_number' => 'required_if:document_country_origin,BR|nullable|string|max:20',
-            'passport_number' => 'required_unless:document_country_origin,BR|nullable|string|max:50',
-            'passport_expiry_date' => 'required_unless:document_country_origin,BR|nullable|date|after:today',
+            'cpf' => 'required_if:document_country_origin,Brazil|nullable|string|max:20',
+            'rg_number' => 'required_if:document_country_origin,Brazil|nullable|string|max:20',
+            'passport_number' => 'required_unless:document_country_origin,Brazil|nullable|string|max:50',
+            'passport_expiry_date' => 'required_unless:document_country_origin,Brazil|nullable|date|after:today',
             'email' => 'required|email|max:255',
             'phone_number' => 'required|string|max:20',
             'address_street' => 'required|string|max:255',
@@ -204,7 +201,7 @@ new #[Layout('layouts.app')] class extends Component {
             'emergency_contact_name' => 'required|string|max:255',
             'emergency_contact_relationship' => 'required|string|max:255',
             'emergency_contact_phone' => 'required|string|max:20',
-            'requires_visa_letter' => 'required_unless:document_country_origin,BR|nullable|string|in:yes,no',
+            'requires_visa_letter' => 'required_unless:document_country_origin,Brazil|nullable|string|in:yes,no',
             'confirm_information' => 'required|accepted',
             'consent_data_processing' => 'required|accepted',
         ]);
@@ -225,10 +222,10 @@ new #[Layout('layouts.app')] class extends Component {
                 'other_gender' => 'required_if:gender,other|string|max:255',
                 'document_country_origin' => 'required|string',
                 'other_document_country_origin' => 'required_if:document_country_origin,OTHER|string|max:255',
-                'cpf' => 'required_if:document_country_origin,BR|nullable|string|max:20',
-                'rg_number' => 'required_if:document_country_origin,BR|nullable|string|max:20',
-                'passport_number' => 'required_unless:document_country_origin,BR|nullable|string|max:50',
-                'passport_expiry_date' => 'required_unless:document_country_origin,BR|nullable|date|after:today',
+                'cpf' => 'required_if:document_country_origin,Brazil|nullable|string|max:20',
+                'rg_number' => 'required_if:document_country_origin,Brazil|nullable|string|max:20',
+                'passport_number' => 'required_unless:document_country_origin,Brazil|nullable|string|max:50',
+                'passport_expiry_date' => 'required_unless:document_country_origin,Brazil|nullable|date|after:today',
                 'email' => 'required|email|max:255',
                 'phone_number' => 'required|string|max:20',
                 'address_street' => 'required|string|max:255',
@@ -251,7 +248,7 @@ new #[Layout('layouts.app')] class extends Component {
                 'emergency_contact_name' => 'required|string|max:255',
                 'emergency_contact_relationship' => 'required|string|max:255',
                 'emergency_contact_phone' => 'required|string|max:20',
-                'requires_visa_letter' => 'required_unless:document_country_origin,BR|nullable|string|in:yes,no',
+                'requires_visa_letter' => 'required_unless:document_country_origin,Brazil|nullable|string|in:yes,no',
                 'confirm_information' => 'required|accepted',
                 'consent_data_processing' => 'required|accepted',
             ]);
@@ -323,8 +320,8 @@ new #[Layout('layouts.app')] class extends Component {
         ]);
         
         // Re-initialize defaults
-        $this->document_country_origin = 'BR';
-        $this->address_country = 'BR';
+        $this->document_country_origin = 'Brazil';
+        $this->address_country = 'Brazil';
         if (auth()->user()) {
             $this->email = auth()->user()->email;
         }
@@ -556,7 +553,7 @@ new #[Layout('layouts.app')] class extends Component {
                                 @endif
                             </div>
 
-                            @if($document_country_origin === 'BR')
+                            @if($document_country_origin === 'Brazil')
                                 <div>
                                     <x-input-label for="cpf" :value="__('CPF')" />
                                     <x-text-input wire:model="cpf" id="cpf" class="block mt-1 w-full" type="text" placeholder="000.000.000-00" required dusk="cpf-input" />
@@ -853,7 +850,7 @@ new #[Layout('layouts.app')] class extends Component {
                     </div>
 
                     {{-- Visa Support --}}
-                    @if($document_country_origin !== 'BR')
+                    @if($document_country_origin !== 'Brazil')
                         <div class="border-b border-gray-200 dark:border-gray-700 pb-8">
                             <h2 class="text-lg font-semibold mb-4 text-usp-blue-pri dark:text-usp-blue-sec">{{ __('8. Visa Support') }}</h2>
                             <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">{{ __('(For international participants only)') }}</p>

--- a/tests/Browser/CountryListTest.php
+++ b/tests/Browser/CountryListTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\DuskTestCase;
+
+class CountryListTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('db:seed', ['--class' => 'EventsTableSeeder']);
+    }
+
+    /**
+     * Test that country dropdown contains the Europe/North America focused list
+     */
+    #[Test]
+    #[Group('dusk')]
+    #[Group('country-list')]
+    public function test_country_dropdown_contains_europe_north_america_focused_list(): void
+    {
+        $user = User::factory()->create();
+
+        $this->browse(function (Browser $browser) use ($user) {
+            $browser->loginAs($user)
+                ->visit('/register-event')
+                ->waitFor('#document_country_origin');
+
+            // Verify the new countries are present in document country dropdown
+            $expectedCountries = [
+                'Azerbaijan',
+                'Belgium',
+                'Brazil',
+                'Canada',
+                'Chile',
+                'France',
+                'Germany',
+                'Greece',
+                'Italy',
+                'Portugal',
+                'United Arab Emirates',
+                'United Kingdom',
+                'United States',
+                'Other',
+            ];
+
+            foreach ($expectedCountries as $country) {
+                if ($country === 'Other') {
+                    $browser->assertSelectHasOption('#document_country_origin', 'OTHER');
+                } else {
+                    $browser->assertSelectHasOption('#document_country_origin', $country);
+                }
+            }
+
+            // Verify the same countries are in address country dropdown
+            $browser->waitFor('[dusk="country-select"]');
+
+            foreach ($expectedCountries as $country) {
+                if ($country === 'Other') {
+                    $browser->assertSelectHasOption('[dusk="country-select"]', 'OTHER');
+                } else {
+                    $browser->assertSelectHasOption('[dusk="country-select"]', $country);
+                }
+            }
+        });
+    }
+
+    /**
+     * Test that old Latin American countries are no longer present (except Brazil and Chile)
+     */
+    #[Test]
+    #[Group('dusk')]
+    #[Group('country-list')]
+    public function test_old_latin_american_countries_removed(): void
+    {
+        $user = User::factory()->create();
+
+        $this->browse(function (Browser $browser) use ($user) {
+            $browser->loginAs($user)
+                ->visit('/register-event')
+                ->waitFor('#document_country_origin');
+
+            // Verify old countries are no longer present
+            $removedCountries = [
+                'AR', // Argentina
+                'CO', // Colombia
+                'MX', // Mexico
+                'PE', // Peru
+                'UY', // Uruguay
+                'VE', // Venezuela
+            ];
+
+            foreach ($removedCountries as $countryCode) {
+                $browser->assertSelectMissingOption('#document_country_origin', $countryCode);
+                $browser->assertSelectMissingOption('[dusk="country-select"]', $countryCode);
+            }
+        });
+    }
+
+    /**
+     * Test that countries display with bilingual format
+     */
+    #[Test]
+    #[Group('dusk')]
+    #[Group('country-list')]
+    public function test_countries_display_bilingual_format(): void
+    {
+        $user = User::factory()->create();
+
+        $this->browse(function (Browser $browser) use ($user) {
+            $browser->loginAs($user)
+                ->visit('/register-event')
+                ->waitFor('#document_country_origin');
+
+            // Check that some countries display in bilingual format
+            // The exact text depends on current locale, but should include both Portuguese and English
+            $browser->assertSeeIn('#document_country_origin', 'Brasil / Brazil')
+                ->assertSeeIn('#document_country_origin', 'Estados Unidos / United States')
+                ->assertSeeIn('#document_country_origin', 'Alemanha / Germany')
+                ->assertSeeIn('#document_country_origin', 'França / France');
+
+            // Same check for address country dropdown
+            $browser->assertSeeIn('[dusk="country-select"]', 'Brasil / Brazil')
+                ->assertSeeIn('[dusk="country-select"]', 'Estados Unidos / United States')
+                ->assertSeeIn('[dusk="country-select"]', 'Alemanha / Germany')
+                ->assertSeeIn('[dusk="country-select"]', 'França / France');
+        });
+    }
+
+    /**
+     * Test that countries are ordered alphabetically by English name
+     */
+    #[Test]
+    #[Group('dusk')]
+    #[Group('country-list')]
+    public function test_countries_ordered_alphabetically_by_english_name(): void
+    {
+        $user = User::factory()->create();
+
+        $this->browse(function (Browser $browser) use ($user) {
+            $browser->loginAs($user)
+                ->visit('/register-event')
+                ->waitFor('#document_country_origin');
+
+            // Get all option values and verify alphabetical order by English name
+            $options = $browser->elements('#document_country_origin option');
+            $countries = [];
+
+            foreach ($options as $option) {
+                $value = $option->getAttribute('value');
+                if (! empty($value)) {
+                    $countries[] = $value;
+                }
+            }
+
+            // Remove the first empty option and OTHER (which should be last)
+            $countries = array_filter($countries, fn ($country) => ! empty($country) && $country !== 'OTHER');
+
+            // Verify alphabetical order
+            $expectedOrder = [
+                'Azerbaijan',
+                'Belgium',
+                'Brazil',
+                'Canada',
+                'Chile',
+                'France',
+                'Germany',
+                'Greece',
+                'Italy',
+                'Portugal',
+                'United Arab Emirates',
+                'United Kingdom',
+                'United States',
+            ];
+
+            $this->assertEquals($expectedOrder, array_values($countries));
+        });
+    }
+}

--- a/tests/Browser/CountryOtherFieldTest.php
+++ b/tests/Browser/CountryOtherFieldTest.php
@@ -59,7 +59,7 @@ class CountryOtherFieldTest extends DuskTestCase
                 ->select('#document_country_origin', 'OTHER')
                 ->waitFor('[dusk="other-document-country-input"]')
                 ->assertVisible('[dusk="other-document-country-input"]')
-                ->select('#document_country_origin', 'BR')
+                ->select('#document_country_origin', 'Brazil')
                 ->waitUntilMissing('[dusk="other-document-country-input"]')
                 ->assertDontSee('[dusk="other-document-country-input"]');
         });
@@ -105,7 +105,7 @@ class CountryOtherFieldTest extends DuskTestCase
                 ->select('[dusk="country-select"]', 'OTHER')
                 ->waitFor('[dusk="other-address-country-input"]')
                 ->assertVisible('[dusk="other-address-country-input"]')
-                ->select('[dusk="country-select"]', 'US')
+                ->select('[dusk="country-select"]', 'United States')
                 ->waitUntilMissing('[dusk="other-address-country-input"]')
                 ->assertDontSee('[dusk="other-address-country-input"]');
         });

--- a/tests/Feature/RegistrationFormConditionalLogicTest.php
+++ b/tests/Feature/RegistrationFormConditionalLogicTest.php
@@ -27,7 +27,7 @@ class RegistrationFormConditionalLogicTest extends TestCase
         $user = User::factory()->create(['email_verified_at' => now()]);
 
         $component = Livewire::test('registration-form')
-            ->set('document_country_origin', 'BR');
+            ->set('document_country_origin', 'Brazil');
 
         $component->assertSee(__('CPF'))
             ->assertSee(__('RG (ID) Number'))
@@ -134,7 +134,7 @@ class RegistrationFormConditionalLogicTest extends TestCase
         $user = User::factory()->create(['email_verified_at' => now()]);
 
         $component = Livewire::test('registration-form')
-            ->set('document_country_origin', 'BR');
+            ->set('document_country_origin', 'Brazil');
 
         $component->assertDontSee(__('8. Visa Support'))
             ->assertDontSee(__('Do you require an invitation letter to get a Brazilian visa?'));
@@ -147,7 +147,7 @@ class RegistrationFormConditionalLogicTest extends TestCase
 
         // Start with Brazil
         $component = Livewire::test('registration-form')
-            ->set('document_country_origin', 'BR');
+            ->set('document_country_origin', 'Brazil');
 
         $component->assertSee(__('CPF'))
             ->assertSee(__('RG (ID) Number'))
@@ -168,7 +168,7 @@ class RegistrationFormConditionalLogicTest extends TestCase
         $user = User::factory()->create(['email_verified_at' => now()]);
 
         $component = Livewire::test('registration-form')
-            ->set('document_country_origin', 'BR')
+            ->set('document_country_origin', 'Brazil')
             ->set('full_name', 'Test User')
             ->set('nationality', 'Brazilian')
             ->set('date_of_birth', '1990-01-01')
@@ -253,7 +253,7 @@ class RegistrationFormConditionalLogicTest extends TestCase
         $user = User::factory()->create(['email_verified_at' => now()]);
 
         $component = Livewire::test('registration-form')
-            ->set('document_country_origin', 'BR');
+            ->set('document_country_origin', 'Brazil');
 
         $component->assertDontSee(__('Please specify the country'));
     }


### PR DESCRIPTION
## Resumo

Esta PR resolve a issue #77, substituindo a lista de países anterior, focada na América Latina, por uma nova lista mais abrangente e adequada ao público internacional do evento. A nova lista, focada na Europa e América do Norte, agora é gerenciada através de um arquivo de configuração e está totalmente internacionalizada usando os recursos de localização do Laravel.

## Mudanças Realizadas

- **Nova Configuração de Países:** Um novo arquivo de configuração `config/countries.php` foi criado para gerenciar a lista de países.
- **Internacionalização:** Traduções em inglês e português para os nomes dos países foram adicionadas em `lang/en/countries.php` e `lang/pt_BR/countries.php`.
- **Formulário de Inscrição Atualizado:** O formulário de inscrição (`resources/views/livewire/registration-form.blade.php`) foi atualizado para usar a nova lista de países internacionalizada.
- **Testes Atualizados:** Testes de browser e de feature foram atualizados para refletir as mudanças na lista de países. Um novo teste de browser, `CountryListTest.php`, foi adicionado para verificar a nova lista.

## Issues Relacionadas

Closes #77

## Testes

- Novos testes de browser em `tests/Browser/CountryListTest.php` verificam se a nova lista de países é exibida corretamente.
- Testes existentes em `tests/Browser/CountryOtherFieldTest.php` e `tests/Feature/RegistrationFormConditionalLogicTest.php` foram atualizados para funcionar com a nova lista de países.
- Todos os testes estão passando.