### PR TITLE
chore(fees): Refina categorias de participantes na tabela de taxas

### DIFF
--- a/resources/views/fees.blade.php
+++ b/resources/views/fees.blade.php
@@ -92,7 +92,15 @@
                                     </tr>
                                     <tr class="bg-gray-50 border-b dark:bg-gray-700 dark:border-gray-600">
                                         <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
-                                            {{ __('Professor - ABE non-member / Professional') }}
+                                            {{ __('Professor (non-ABE)') }}
+                                        </th>
+                                        <td class="px-6 py-4 text-center font-semibold">R$ 1,600</td>
+                                        <td class="px-6 py-4 text-center font-semibold">R$ 2,000</td>
+                                        <td class="px-6 py-4 text-center font-semibold">R$ 800</td>
+                                    </tr>
+                                    <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+                                        <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                                            {{ __('Professional / Foreign Participant') }}
                                         </th>
                                         <td class="px-6 py-4 text-center font-semibold">R$ 1,600</td>
                                         <td class="px-6 py-4 text-center font-semibold">R$ 2,000</td>
@@ -160,7 +168,24 @@
                                     </tr>
                                     <tr class="bg-gray-50 border-b dark:bg-gray-700 dark:border-gray-600">
                                         <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
-                                            {{ __('Professor - ABE non-member / Professional') }}
+                                            {{ __('Professor (non-ABE)') }}
+                                        </th>
+                                        <td class="px-6 py-4 text-center">
+                                            <span class="font-semibold">R$ 700</span>
+                                            <span class="text-sm text-purple-600 dark:text-purple-400 block">(R$ 500)*</span>
+                                        </td>
+                                        <td class="px-6 py-4 text-center">
+                                            <span class="font-semibold">R$ 850</span>
+                                            <span class="text-sm text-purple-600 dark:text-purple-400 block">(R$ 650)*</span>
+                                        </td>
+                                        <td class="px-6 py-4 text-center">
+                                            <span class="font-semibold">R$ 350</span>
+                                            <span class="text-sm text-purple-600 dark:text-purple-400 block">(R$ 200)*</span>
+                                        </td>
+                                    </tr>
+                                    <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700">
+                                        <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
+                                            {{ __('Professional / Foreign Participant') }}
                                         </th>
                                         <td class="px-6 py-4 text-center">
                                             <span class="font-semibold">R$ 700</span>

--- a/tests/Feature/FeesPageTest.php
+++ b/tests/Feature/FeesPageTest.php
@@ -41,7 +41,8 @@ class FeesPageTest extends TestCase
         $response->assertSee(__('Undergraduate Student'));
         $response->assertSee(__('Graduate Student'));
         $response->assertSee(__('Professor - ABE member'));
-        $response->assertSee(__('Professor - ABE non-member / Professional'));
+        $response->assertSee(__('Professor (non-ABE)'));
+        $response->assertSee(__('Professional / Foreign Participant'));
     }
 
     /**


### PR DESCRIPTION
## Resumo

Este pull request refina a exibição das categorias de participantes na página de taxas para fornecer maior clareza, conforme descrito na issue #79. O objetivo principal é distinguir melhor entre "Professor (não-ABE)" e "Profissional / Participante Estrangeiro" sem alterar a estrutura de preços subjacente.

## Mudanças Realizadas

- **`resources/views/fees.blade.php`**:
  - A linha única da tabela para "Professor - não membro da ABE / Profissional" foi dividida em duas linhas distintas:
    - "Professor (não-ABE)"
    - "Profissional / Participante Estrangeiro"
  - Essa alteração se aplica tanto à tabela principal de taxas quanto à tabela com descontos especiais.

- **`tests/Feature/FeesPageTest.php`**:
  - O teste de feature que verifica o conteúdo da página de taxas foi atualizado para validar a presença dos novos e mais específicos nomes de categoria.

## Issues Relacionadas

Closes #79

## Testes

- Os testes de feature existentes foram atualizados para se alinharem às mudanças na UI.
- Todos os testes estão passando.