### PR TITLE
feat(email): Aprimora conteúdo de emails e adiciona lembretes

### DIFF
--- a/app/Mail/NewRegistrationNotification.php
+++ b/app/Mail/NewRegistrationNotification.php
@@ -42,6 +42,11 @@ class NewRegistrationNotification extends Mailable implements ShouldQueue
             }
         }
 
+        // Add CC to assoc.bras.estatistica@gmail.com for international participants
+        if (! $this->forCoordinator && $this->registration->document_country_origin !== 'Brazil') {
+            $envelope->cc('assoc.bras.estatistica@gmail.com');
+        }
+
         return $envelope;
     }
 

--- a/app/Mail/NewRegistrationNotification.php
+++ b/app/Mail/NewRegistrationNotification.php
@@ -59,8 +59,17 @@ class NewRegistrationNotification extends Mailable implements ShouldQueue
             ? 'emails.registration.new-coordinator'
             : 'emails.registration.new';
 
+        $data = ['registration' => $this->registration];
+
+        // Add early bird reminder data for participant emails only
+        if (! $this->forCoordinator) {
+            $data['showEarlyBirdReminder'] = $this->shouldShowEarlyBirdReminder();
+            $data['earlyBirdDeadline'] = $this->getEarlyBirdDeadline();
+        }
+
         return new Content(
             markdown: $template,
+            with: $data,
         );
     }
 
@@ -82,5 +91,33 @@ class NewRegistrationNotification extends Mailable implements ShouldQueue
         $email = config('mail.coordinator_email');
 
         return is_string($email) ? $email : null;
+    }
+
+    /**
+     * Determine if early bird reminder should be shown.
+     */
+    private function shouldShowEarlyBirdReminder(): bool
+    {
+        // Check if there's an amount due
+        if ($this->registration->calculateCorrectTotalFee() <= 0) {
+            return false;
+        }
+
+        // Get the early bird deadline from the first event
+        $earlyBirdDeadline = $this->getEarlyBirdDeadline();
+        if (! $earlyBirdDeadline) {
+            return false;
+        }
+
+        // Check if we're still within the early bird period
+        return now() <= $earlyBirdDeadline;
+    }
+
+    /**
+     * Get the early bird deadline from registration events.
+     */
+    private function getEarlyBirdDeadline(): ?\Illuminate\Support\Carbon
+    {
+        return $this->registration->events->first()?->registration_deadline_early;
     }
 }

--- a/app/Mail/RegistrationModifiedNotification.php
+++ b/app/Mail/RegistrationModifiedNotification.php
@@ -36,6 +36,11 @@ class RegistrationModifiedNotification extends Mailable implements ShouldQueue
             }
         }
 
+        // Add CC to assoc.bras.estatistica@gmail.com for international participants
+        if (! $this->forCoordinator && $this->registration->document_country_origin !== 'Brazil') {
+            $envelope->cc('assoc.bras.estatistica@gmail.com');
+        }
+
         return $envelope;
     }
 

--- a/app/Mail/RegistrationModifiedNotification.php
+++ b/app/Mail/RegistrationModifiedNotification.php
@@ -62,12 +62,20 @@ class RegistrationModifiedNotification extends Mailable implements ShouldQueue
             $this->registration
         );
 
+        $data = [
+            'registration' => $this->registration,
+            'feeCalculation' => $feeCalculation,
+        ];
+
+        // Add early bird reminder data for participant emails only
+        if (! $this->forCoordinator) {
+            $data['showEarlyBirdReminder'] = $this->shouldShowEarlyBirdReminder($feeCalculation);
+            $data['earlyBirdDeadline'] = $this->getEarlyBirdDeadline();
+        }
+
         return new Content(
             markdown: $template,
-            with: [
-                'registration' => $this->registration,
-                'feeCalculation' => $feeCalculation,
-            ],
+            with: $data,
         );
     }
 
@@ -84,5 +92,35 @@ class RegistrationModifiedNotification extends Mailable implements ShouldQueue
         $email = config('mail.coordinator_email');
 
         return is_string($email) ? $email : null;
+    }
+
+    /**
+     * Determine if early bird reminder should be shown.
+     *
+     * @param  array<string, mixed>  $feeCalculation
+     */
+    private function shouldShowEarlyBirdReminder(array $feeCalculation): bool
+    {
+        // Check if there's an amount due
+        if ($feeCalculation['amount_due'] <= 0) {
+            return false;
+        }
+
+        // Get the early bird deadline from the first event
+        $earlyBirdDeadline = $this->getEarlyBirdDeadline();
+        if (! $earlyBirdDeadline) {
+            return false;
+        }
+
+        // Check if we're still within the early bird period
+        return now() <= $earlyBirdDeadline;
+    }
+
+    /**
+     * Get the early bird deadline from registration events.
+     */
+    private function getEarlyBirdDeadline(): ?\Illuminate\Support\Carbon
+    {
+        return $this->registration->events->first()?->registration_deadline_early;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Notifications\ResetPassword;
+use App\Notifications\VerifyEmail;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -72,5 +74,21 @@ class User extends Authenticatable implements MustVerifyEmail
     public function registrations(): HasMany
     {
         return $this->hasMany(Registration::class);
+    }
+
+    /**
+     * Send the email verification notification.
+     */
+    public function sendEmailVerificationNotification(): void
+    {
+        $this->notify(new VerifyEmail);
+    }
+
+    /**
+     * Send the password reset notification.
+     */
+    public function sendPasswordResetNotification($token): void
+    {
+        $this->notify(new ResetPassword($token));
     }
 }

--- a/app/Notifications/ResetPassword.php
+++ b/app/Notifications/ResetPassword.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\ResetPassword as BaseResetPassword;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class ResetPassword extends BaseResetPassword implements ShouldQueue
+{
+    use Queueable;
+}

--- a/app/Notifications/VerifyEmail.php
+++ b/app/Notifications/VerifyEmail.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\VerifyEmail as BaseVerifyEmail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class VerifyEmail extends BaseVerifyEmail implements ShouldQueue
+{
+    use Queueable;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -19,6 +19,7 @@
     "An error occurred during validation: ": "An error occurred during validation: ",
     "An unexpected error occurred. Please try again or contact support.": "An unexpected error occurred. Please try again or contact support.",
     "An error occurred during form submission. Please try again.": "An error occurred during form submission. Please try again.",
+    "As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.": "As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.",
     "You must select at least one event to register.": "You must select at least one event to register.",
     "Unable to calculate registration fees. Please try again or contact support.": "Unable to calculate registration fees. Please try again or contact support.",
     "You must be logged in to create a registration. Please log in and try again.": "You must be logged in to create a registration. Please log in and try again.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -659,5 +659,6 @@
     "View Enrollment Proof in Admin Panel": "View Enrollment Proof in Admin Panel",
     "View Payment Proof in Admin Panel": "View Payment Proof in Admin Panel",
     "System": "System",
-    "Free workshop for graduate students": "Free workshop for graduate students"
+    "Free workshop for graduate students": "Free workshop for graduate students",
+    "Thank you for your registration. Your invoice for international payment will be sent shortly from assoc.bras.estatistica@gmail.com. Please check your inbox and spam folder.": "Thank you for your registration. Your invoice for international payment will be sent shortly from assoc.bras.estatistica@gmail.com. Please check your inbox and spam folder."
 }

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -694,5 +694,6 @@
     "View Enrollment Proof in Admin Panel": "Visualizar Comprovante de Matrícula no Painel Admin",
     "View Payment Proof in Admin Panel": "Visualizar Comprovante de Pagamento no Painel Admin",
     "System": "Sistema",
-    "Free workshop for graduate students": "Workshop gratuito para estudantes de pós-graduação"
+    "Free workshop for graduate students": "Workshop gratuito para estudantes de pós-graduação",
+    "Thank you for your registration. Your invoice for international payment will be sent shortly from assoc.bras.estatistica@gmail.com. Please check your inbox and spam folder.": "Obrigado pela sua inscrição. Sua fatura para pagamento internacional será enviada em breve de assoc.bras.estatistica@gmail.com. Por favor, verifique sua caixa de entrada e pasta de spam."
 }

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -19,6 +19,7 @@
     "An error occurred during validation: ": "Ocorreu um erro durante a validação: ",
     "An unexpected error occurred. Please try again or contact support.": "Ocorreu um erro inesperado. Tente novamente ou entre em contato com o suporte.",
     "An error occurred during form submission. Please try again.": "Ocorreu um erro durante o envio do formulário. Tente novamente.",
+    "As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.": "Como aluno de graduação, sua taxa é zero. No lugar do comprovante de pagamento, solicitamos que envie um comprovante de matrícula válido.",
     "You must select at least one event to register.": "Você deve selecionar pelo menos um evento para se inscrever.",
     "Unable to calculate registration fees. Please try again or contact support.": "Não foi possível calcular as taxas de inscrição. Tente novamente ou entre em contato com o suporte.",
     "You must be logged in to create a registration. Please log in and try again.": "Você deve estar logado para criar uma inscrição. Faça login e tente novamente.",

--- a/resources/views/emails/registration/modified.blade.php
+++ b/resources/views/emails/registration/modified.blade.php
@@ -48,6 +48,12 @@
 **{{ __('Payment Status') }}:** {{ __('No additional payment required') }}
 @endif
 
+@if(isset($showEarlyBirdReminder) && $showEarlyBirdReminder && isset($earlyBirdDeadline))
+## {{ __('Early Bird Reminder') }}
+
+{{ __('Don\'t miss the early bird discount! Complete your payment before') }} **{{ $earlyBirdDeadline->format('d/m/Y') }}** {{ __('to secure the reduced rates shown above.') }}
+@endif
+
 ## {{ __('Next Steps') }}
 
 {{ __('You can access your registration details at any time through your account on our system.') }}

--- a/resources/views/emails/registration/new.blade.php
+++ b/resources/views/emails/registration/new.blade.php
@@ -43,6 +43,12 @@
 **{{ __('Payment Status') }}:** {{ __('Fee exempt') }}
 @endif
 
+@if(isset($showEarlyBirdReminder) && $showEarlyBirdReminder && isset($earlyBirdDeadline))
+## {{ __('Early Bird Reminder') }}
+
+{{ __('Don\'t miss the early bird discount! Complete your payment before') }} **{{ $earlyBirdDeadline->format('d/m/Y') }}** {{ __('to secure the reduced rates shown above.') }}
+@endif
+
 ## {{ __('Next Steps') }}
 
 {{ __('Keep this email for your records. We will contact you soon with more information about the event.') }}

--- a/resources/views/emails/registration/new.blade.php
+++ b/resources/views/emails/registration/new.blade.php
@@ -34,7 +34,7 @@
 {{ __('After making payment, access your account in the system and upload the payment proof. Your status will be updated once confirmation is processed.') }}
 @else
 **{{ __('Invoice Information') }}:**
-{{ __('An invoice with details for international payment will be sent to your email shortly.') }}
+{{ __('Thank you for your registration. Your invoice for international payment will be sent shortly from assoc.bras.estatistica@gmail.com. Please check your inbox and spam folder.') }}
 @endif
 @else
 **{{ __('Payment Status') }}:** {{ __('Fee exempt') }}

--- a/resources/views/emails/registration/new.blade.php
+++ b/resources/views/emails/registration/new.blade.php
@@ -12,12 +12,12 @@
 - {{ $event->name }}: R$ {{ number_format((float) $event->pivot->price_at_registration, 2, ',', '.') }}
 @endforeach
 
-**{{ __('Total Amount') }}:** R$ {{ number_format($registration->events->sum('pivot.price_at_registration'), 2, ',', '.') }}
+**{{ __('Total Amount') }}:** R$ {{ number_format($registration->calculateCorrectTotalFee(), 2, ',', '.') }}
 
-@if($registration->position === 'undergraduate_student' && $registration->events->sum('pivot.price_at_registration') == 0)
+@if($registration->position === 'undergraduate_student' && $registration->calculateCorrectTotalFee() == 0)
 **{{ __('Enrollment Information') }}:**
 {{ __('As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.') }}
-@elseif($registration->events->sum('pivot.price_at_registration') > 0)
+@elseif($registration->calculateCorrectTotalFee() > 0)
 **{{ __('Payment Status') }}:** {{ ucfirst(str_replace('_', ' ', $registration->payment_status)) }}
 
 @if($registration->document_country_origin === 'Brazil')

--- a/resources/views/emails/registration/new.blade.php
+++ b/resources/views/emails/registration/new.blade.php
@@ -14,7 +14,10 @@
 
 **{{ __('Total Amount') }}:** R$ {{ number_format($registration->events->sum('pivot.price_at_registration'), 2, ',', '.') }}
 
-@if($registration->events->sum('pivot.price_at_registration') > 0)
+@if($registration->position === 'undergraduate_student' && $registration->events->sum('pivot.price_at_registration') == 0)
+**{{ __('Enrollment Information') }}:**
+{{ __('As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.') }}
+@elseif($registration->events->sum('pivot.price_at_registration') > 0)
 **{{ __('Payment Status') }}:** {{ ucfirst(str_replace('_', ' ', $registration->payment_status)) }}
 
 @if($registration->document_country_origin === 'Brazil')

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
+use App\Notifications\VerifyEmail as VerifyEmailNotification;
 use Database\Seeders\RoleSeeder;
 use Illuminate\Auth\Events\Verified;
-use Illuminate\Auth\Notifications\VerifyEmail as VerifyEmailNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
-use Illuminate\Auth\Notifications\ResetPassword;
+use App\Notifications\ResetPassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Password; // Importa o facade Password

--- a/tests/Feature/Http/Controllers/RegistrationControllerTest.php
+++ b/tests/Feature/Http/Controllers/RegistrationControllerTest.php
@@ -1146,6 +1146,8 @@ class RegistrationControllerTest extends TestCase
             'user_id' => $user->id,
             'full_name' => 'João Silva',
             'document_country_origin' => 'Brazil',
+            'position' => 'postgraduate_student',
+            'registration_category_snapshot' => 'grad_student',
             'payment_status' => 'pending_payment',
         ]);
 
@@ -1181,6 +1183,8 @@ class RegistrationControllerTest extends TestCase
             'user_id' => $user->id,
             'full_name' => 'John Doe',
             'document_country_origin' => 'US',
+            'position' => 'postgraduate_student',
+            'registration_category_snapshot' => 'grad_student',
             'payment_status' => 'pending_payment',
         ]);
 

--- a/tests/Feature/Http/Controllers/RegistrationControllerTest.php
+++ b/tests/Feature/Http/Controllers/RegistrationControllerTest.php
@@ -1192,8 +1192,8 @@ class RegistrationControllerTest extends TestCase
         $mailable = new \App\Mail\NewRegistrationNotification($registration);
         $renderedContent = $mailable->render();
 
-        // AC4: Verify international invoice message is included
-        $this->assertStringContainsString('invoice com detalhes para pagamento internacional será enviada', $renderedContent);
+        // AC4: Verify international invoice message is included (AC1 requirement)
+        $this->assertStringContainsString('Obrigado pela sua inscrição. Sua fatura para pagamento internacional será enviada em breve de assoc.bras.estatistica@gmail.com. Por favor, verifique sua caixa de entrada e pasta de spam.', $renderedContent);
 
         // Should NOT contain Brazilian payment instructions for international users
         $this->assertStringNotContainsString('Instruções para Pagamento', $renderedContent);
@@ -1340,9 +1340,9 @@ class RegistrationControllerTest extends TestCase
             if ($mail->registration->id === $registration->id && $mail->forCoordinator === false) {
                 $content = $mail->render();
 
-                // Verify international payment instructions are included
-                $this->assertStringContainsString(__('Invoice Information'), $content);
-                $this->assertStringContainsString(__('An invoice with details for international payment will be sent to your email shortly.'), $content);
+                // Verify international payment instructions are included (AC1 requirement)
+                $this->assertStringContainsString('Invoice Information', $content);
+                $this->assertStringContainsString('Thank you for your registration. Your invoice for international payment will be sent shortly from assoc.bras.estatistica@gmail.com. Please check your inbox and spam folder.', $content);
 
                 // Verify user and registration data
                 $this->assertStringContainsString($registration->full_name, $content);

--- a/tests/Feature/Mail/NewRegistrationNotificationFeatureTest.php
+++ b/tests/Feature/Mail/NewRegistrationNotificationFeatureTest.php
@@ -1,0 +1,409 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Mail\NewRegistrationNotification;
+use App\Models\Event;
+use App\Models\Registration;
+use App\Models\User;
+use Database\Seeders\EventsTableSeeder;
+use Database\Seeders\FeesTableSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[CoversClass(NewRegistrationNotification::class)]
+#[Group('mail')]
+#[Group('feature')]
+#[Group('new-registration-notification-feature')]
+class NewRegistrationNotificationFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+        $this->seed(EventsTableSeeder::class);
+        $this->seed(FeesTableSeeder::class);
+    }
+
+    #[Test]
+    public function registration_creation_sends_email_with_cc_for_international_participants(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create([
+            'email' => 'international@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user);
+
+        $event = Event::first();
+        $registrationData = $this->getValidRegistrationData($user, [
+            'document_country_origin' => 'US', // International participant
+            'cpf' => null, // International doesn't have CPF
+            'rg_number' => null, // International doesn't have RG
+            'passport_number' => 'ABC123456', // International needs passport
+            'passport_expiry_date' => '2030-12-31', // Passport expiry
+            'position' => 'graduate_student',
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        // Create registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('event-registrations.store'), $registrationData);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify that emails were queued
+        Mail::assertQueued(NewRegistrationNotification::class);
+
+        // Get the queued emails and examine them
+        $queuedEmails = collect(Mail::queued(NewRegistrationNotification::class));
+        $participantEmail = $queuedEmails->where('forCoordinator', false)->first();
+        $this->assertNotNull($participantEmail, 'Participant email should be queued');
+
+        // Verify international participant details
+        $this->assertEquals('US', $participantEmail->registration->document_country_origin);
+
+        // AC2: Verify CC was added to international participant email
+        $envelope = $participantEmail->envelope();
+        $this->assertEquals(1, count($envelope->cc), 'International participant email should have CC');
+        $this->assertEquals('assoc.bras.estatistica@gmail.com', $envelope->cc[0]->address);
+
+        // AC1: Verify the email content contains international message
+        $rendered = $participantEmail->render();
+        $this->assertTrue(
+            str_contains($rendered, 'invoice for international payment') && str_contains($rendered, 'assoc.bras.estatistica@gmail.com'),
+            'Email should contain international message with invoice and email reference'
+        );
+    }
+
+    #[Test]
+    public function registration_creation_sends_email_without_cc_for_brazilian_participants(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create([
+            'email' => 'brazilian@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user);
+
+        $event = Event::first();
+        $registrationData = $this->getValidRegistrationData($user, [
+            'document_country_origin' => 'Brazil', // Brazilian participant
+            'position' => 'graduate_student',
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        // Create registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('event-registrations.store'), $registrationData);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify that Brazilian participant email does NOT have CC
+        Mail::assertQueued(NewRegistrationNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            $envelope = $mail->envelope();
+
+            return count($envelope->cc) === 0;
+        });
+
+        // Verify the email does NOT contain international message
+        Mail::assertQueued(NewRegistrationNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            $rendered = $mail->render();
+
+            // Should NOT contain international text
+            return ! str_contains($rendered, 'Thank you for your registration. Your invoice for international payment will be sent shortly from `assoc.bras.estatistica@gmail.com`. Please check your inbox and spam folder.');
+        });
+    }
+
+    #[Test]
+    public function registration_creation_sends_email_with_undergraduate_message_for_zero_fee(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create([
+            'email' => 'undergraduate@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user);
+
+        $event = Event::first();
+        $registrationData = $this->getValidRegistrationData($user, [
+            'position' => 'undergraduate_student', // AC4: undergraduate_student position
+            'selected_event_codes' => [$event->code],
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('event-registrations.store'), $registrationData);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify email contains undergraduate message when position is undergraduate_student AND total_fee is zero
+        Mail::assertQueued(NewRegistrationNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            // AC4: Check that position is undergraduate_student and total_fee is zero
+            if ($mail->registration->position !== 'undergraduate_student') {
+                return true; // Not an undergraduate, skip
+            }
+
+            $totalFee = $mail->registration->calculateCorrectTotalFee();
+            if ($totalFee > 0) {
+                return true; // Has fee, skip
+            }
+
+            $rendered = $mail->render();
+
+            // AC3: Check for exact undergraduate text
+            return str_contains($rendered, 'As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.');
+        });
+    }
+
+    #[Test]
+    public function registration_creation_does_not_show_undergraduate_message_for_non_undergraduate(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create([
+            'email' => 'graduate@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user);
+
+        $event = Event::first();
+        $registrationData = $this->getValidRegistrationData($user, [
+            'position' => 'graduate_student', // Not undergraduate
+            'selected_event_codes' => [$event->code],
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('event-registrations.store'), $registrationData);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify email does NOT contain undergraduate message for non-undergraduate
+        Mail::assertQueued(NewRegistrationNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            $rendered = $mail->render();
+
+            // Should NOT contain undergraduate message for graduate student
+            return ! str_contains($rendered, 'As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.');
+        });
+    }
+
+    #[Test]
+    public function registration_creation_shows_early_bird_reminder_during_early_bird_period_with_pending_amount(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create([
+            'email' => 'earlybird@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user);
+
+        // Set up event with early bird deadline in the future
+        $event = Event::first();
+        $event->update([
+            'registration_deadline_early' => Carbon::now()->addDays(5), // Early bird still active
+        ]);
+
+        $registrationData = $this->getValidRegistrationData($user, [
+            'position' => 'graduate_student', // Position that has a fee
+            'selected_event_codes' => [$event->code],
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('event-registrations.store'), $registrationData);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // AC5: Verify email contains early bird reminder when conditions are met
+        Mail::assertQueued(NewRegistrationNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            // Check if there's an amount due
+            $totalFee = $mail->registration->calculateCorrectTotalFee();
+            if ($totalFee <= 0) {
+                return true; // No amount due, skip
+            }
+
+            // Check if early bird deadline is in the future
+            $earlyBirdDeadline = $mail->registration->events->first()?->registration_deadline_early;
+            if (! $earlyBirdDeadline || Carbon::now() > $earlyBirdDeadline) {
+                return true; // Early bird period over, skip
+            }
+
+            $rendered = $mail->render();
+
+            // Should contain early bird reminder
+            return str_contains($rendered, 'early bird') || str_contains($rendered, 'Early Bird');
+        });
+    }
+
+    #[Test]
+    public function registration_creation_does_not_show_early_bird_reminder_after_deadline(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create([
+            'email' => 'late@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user);
+
+        // Set up event with early bird deadline in the past
+        $event = Event::first();
+        $event->update([
+            'registration_deadline_early' => Carbon::now()->subDays(5), // Early bird period over
+        ]);
+
+        $registrationData = $this->getValidRegistrationData($user, [
+            'position' => 'graduate_student', // Position that has a fee
+            'selected_event_codes' => [$event->code],
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('event-registrations.store'), $registrationData);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify email does NOT contain early bird reminder after deadline
+        Mail::assertQueued(NewRegistrationNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            $rendered = $mail->render();
+
+            // Should NOT contain early bird reminder after deadline
+            return ! str_contains($rendered, 'early bird') && ! str_contains($rendered, 'Early Bird');
+        });
+    }
+
+    #[Test]
+    public function registration_creation_does_not_show_early_bird_reminder_with_zero_amount(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create([
+            'email' => 'zerofee@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user);
+
+        // Set up event with early bird deadline in the future
+        $event = Event::first();
+        $event->update([
+            'registration_deadline_early' => Carbon::now()->addDays(5), // Early bird still active
+        ]);
+
+        $registrationData = $this->getValidRegistrationData($user, [
+            'position' => 'undergraduate_student', // Position with zero fee
+            'selected_event_codes' => [$event->code],
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('event-registrations.store'), $registrationData);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify email does NOT contain early bird reminder when amount is zero
+        Mail::assertQueued(NewRegistrationNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            // Check if there's no amount due
+            $totalFee = $mail->registration->calculateCorrectTotalFee();
+            if ($totalFee > 0) {
+                return true; // Has amount due, skip this check
+            }
+
+            $rendered = $mail->render();
+
+            // Should NOT contain early bird reminder when no amount due
+            return ! str_contains($rendered, 'early bird') && ! str_contains($rendered, 'Early Bird');
+        });
+    }
+
+    /**
+     * Helper to get valid data for registration.
+     */
+    private function getValidRegistrationData(User $user, array $overrides = []): array
+    {
+        $event = Event::first();
+
+        return array_merge([
+            'full_name' => $user->name,
+            'nationality' => 'Brazilian',
+            'date_of_birth' => '1990-01-01',
+            'gender' => 'male',
+            'document_country_origin' => 'Brazil',
+            'cpf' => '123.456.789-00',
+            'rg_number' => '1234567',
+            'passport_number' => null,
+            'passport_expiry_date' => null,
+            'email' => $user->email,
+            'phone_number' => '+55 11 987654321',
+            'address_street' => 'Rua Exemplo, 123',
+            'address_city' => 'São Paulo',
+            'address_state_province' => 'SP',
+            'address_country' => 'BR',
+            'address_postal_code' => '01000-000',
+            'affiliation' => 'University of Example',
+            'position' => 'graduate_student',
+            'is_abe_member' => false,
+            'arrival_date' => '2025-09-28',
+            'departure_date' => '2025-10-03',
+            'selected_event_codes' => [$event->code],
+            'participation_format' => 'in-person',
+            'needs_transport_from_gru' => false,
+            'needs_transport_from_usp' => false,
+            'dietary_restrictions' => 'none',
+            'other_dietary_restrictions' => null,
+            'emergency_contact_name' => 'Emergency Contact',
+            'emergency_contact_relationship' => 'Friend',
+            'emergency_contact_phone' => '+55 11 912345678',
+            'requires_visa_letter' => false,
+            'sou_da_usp' => false,
+            'codpes' => null,
+            'confirm_information_accuracy' => true,
+            'confirm_data_processing_consent' => true,
+        ], $overrides);
+    }
+}

--- a/tests/Feature/Mail/RegistrationModifiedNotificationFeatureTest.php
+++ b/tests/Feature/Mail/RegistrationModifiedNotificationFeatureTest.php
@@ -1,0 +1,372 @@
+<?php
+
+namespace Tests\Feature\Mail;
+
+use App\Mail\RegistrationModifiedNotification;
+use App\Models\Event;
+use App\Models\Registration;
+use App\Models\User;
+use Database\Seeders\EventsTableSeeder;
+use Database\Seeders\FeesTableSeeder;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[CoversClass(RegistrationModifiedNotification::class)]
+#[Group('mail')]
+#[Group('feature')]
+#[Group('registration-modified-notification-feature')]
+class RegistrationModifiedNotificationFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+        $this->seed(EventsTableSeeder::class);
+        $this->seed(FeesTableSeeder::class);
+    }
+
+    #[Test]
+    public function registration_modification_sends_email_with_cc_for_international_participants(): void
+    {
+        Mail::fake();
+        config(['mail.coordinator_email' => 'coordinator@example.com']);
+
+        $user = User::factory()->create([
+            'email' => 'international@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        // Create initial registration for international participant
+        $registration = Registration::factory()->for($user)->create([
+            'registration_category_snapshot' => 'grad_student',
+            'participation_format' => 'in-person',
+            'document_country_origin' => 'US', // International participant
+            'position' => 'graduate_student',
+        ]);
+
+        $event = Event::first();
+
+        $this->actingAs($user);
+
+        // Modify registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('registration.modify', $registration), [
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // AC2: Verify CC was added to international participant email
+        Mail::assertQueued(RegistrationModifiedNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            $envelope = $mail->envelope();
+
+            return count($envelope->cc) === 1 &&
+                   $envelope->cc[0]->address === 'assoc.bras.estatistica@gmail.com';
+        });
+
+        // Verify that user email was queued for international participant
+        Mail::assertQueued(RegistrationModifiedNotification::class, function ($mail) {
+            return ! $mail->forCoordinator && $mail->registration->document_country_origin === 'US';
+        });
+    }
+
+    #[Test]
+    public function registration_modification_sends_email_without_cc_for_brazilian_participants(): void
+    {
+        Mail::fake();
+        config(['mail.coordinator_email' => 'coordinator@example.com']);
+
+        $user = User::factory()->create([
+            'email' => 'brazilian@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        // Create initial registration for Brazilian participant
+        $registration = Registration::factory()->for($user)->create([
+            'registration_category_snapshot' => 'grad_student',
+            'participation_format' => 'in-person',
+            'document_country_origin' => 'Brazil', // Brazilian participant
+            'position' => 'graduate_student',
+        ]);
+
+        $event = Event::first();
+
+        $this->actingAs($user);
+
+        // Modify registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('registration.modify', $registration), [
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify that Brazilian participant email does NOT have CC
+        Mail::assertQueued(RegistrationModifiedNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            $envelope = $mail->envelope();
+
+            return count($envelope->cc) === 0;
+        });
+    }
+
+    #[Test]
+    public function registration_modification_shows_early_bird_reminder_during_early_bird_period_with_pending_amount(): void
+    {
+        Mail::fake();
+        config(['mail.coordinator_email' => 'coordinator@example.com']);
+
+        $user = User::factory()->create([
+            'email' => 'earlybird@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        // Set up event with early bird deadline in the future
+        $event = Event::first();
+        $event->update([
+            'registration_deadline_early' => Carbon::now()->addDays(5), // Early bird still active
+        ]);
+
+        // Create initial registration with a fee
+        $registration = Registration::factory()->for($user)->create([
+            'registration_category_snapshot' => 'grad_student', // Category that has fees
+            'participation_format' => 'in-person',
+            'document_country_origin' => 'Brazil',
+            'position' => 'graduate_student',
+        ]);
+
+        // Don't pre-attach events to allow modification to trigger
+
+        $this->actingAs($user);
+
+        // Modify registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('registration.modify', $registration), [
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // AC5: Verify email contains early bird reminder when conditions are met
+        // First check that emails were queued
+        Mail::assertQueued(RegistrationModifiedNotification::class, 2);
+
+        // Then manually check the participant email content
+        $queuedEmails = collect(Mail::queued(RegistrationModifiedNotification::class));
+        $participantEmail = $queuedEmails->where('forCoordinator', false)->first();
+        $this->assertNotNull($participantEmail, 'Participant email should be queued');
+
+        $rendered = $participantEmail->render();
+        $this->assertTrue(
+            str_contains($rendered, 'early bird') || str_contains($rendered, 'Early Bird'),
+            'Email should contain early bird reminder'
+        );
+    }
+
+    #[Test]
+    public function registration_modification_does_not_show_early_bird_reminder_after_deadline(): void
+    {
+        Mail::fake();
+        config(['mail.coordinator_email' => 'coordinator@example.com']);
+
+        $user = User::factory()->create([
+            'email' => 'late@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        // Set up event with early bird deadline in the past
+        $event = Event::first();
+        $event->update([
+            'registration_deadline_early' => Carbon::now()->subDays(5), // Early bird period over
+        ]);
+
+        // Create initial registration with a fee
+        $registration = Registration::factory()->for($user)->create([
+            'registration_category_snapshot' => 'grad_student', // Category that has fees
+            'participation_format' => 'in-person',
+            'document_country_origin' => 'Brazil',
+            'position' => 'graduate_student',
+        ]);
+
+        // Don't pre-attach events to allow modification to trigger
+
+        $this->actingAs($user);
+
+        // Modify registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('registration.modify', $registration), [
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify email does NOT contain early bird reminder after deadline
+        // First check that emails were queued
+        Mail::assertQueued(RegistrationModifiedNotification::class, 2);
+
+        // Then manually check the participant email content
+        $queuedEmails = collect(Mail::queued(RegistrationModifiedNotification::class));
+        $participantEmail = $queuedEmails->where('forCoordinator', false)->first();
+        $this->assertNotNull($participantEmail, 'Participant email should be queued');
+
+        $rendered = $participantEmail->render();
+        $this->assertFalse(
+            str_contains($rendered, 'early bird') || str_contains($rendered, 'Early Bird'),
+            'Email should NOT contain early bird reminder after deadline'
+        );
+    }
+
+    #[Test]
+    public function registration_modification_does_not_show_early_bird_reminder_with_zero_amount(): void
+    {
+        Mail::fake();
+        config(['mail.coordinator_email' => 'coordinator@example.com']);
+
+        $user = User::factory()->create([
+            'email' => 'zerofee@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        // Set up event with early bird deadline in the future
+        $event = Event::first();
+        $event->update([
+            'registration_deadline_early' => Carbon::now()->addDays(5), // Early bird still active
+        ]);
+
+        // Create initial registration with zero fee
+        $registration = Registration::factory()->for($user)->create([
+            'registration_category_snapshot' => 'undergrad_student', // Category with zero fee
+            'participation_format' => 'in-person',
+            'document_country_origin' => 'Brazil',
+            'position' => 'undergraduate_student',
+        ]);
+
+        // Don't pre-attach events to allow modification to trigger
+
+        $this->actingAs($user);
+
+        // Modify registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('registration.modify', $registration), [
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify email does NOT contain early bird reminder when amount is zero
+        Mail::assertQueued(RegistrationModifiedNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            $rendered = $mail->render();
+
+            // Should NOT contain early bird reminder when no amount due
+            return ! str_contains($rendered, 'early bird') && ! str_contains($rendered, 'Early Bird');
+        });
+    }
+
+    #[Test]
+    public function registration_modification_sends_emails_to_both_participant_and_coordinator(): void
+    {
+        Mail::fake();
+        config(['mail.coordinator_email' => 'coordinator@example.com']);
+
+        $user = User::factory()->create([
+            'email' => 'participant@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        // Create initial registration
+        $registration = Registration::factory()->for($user)->create([
+            'registration_category_snapshot' => 'grad_student',
+            'participation_format' => 'in-person',
+            'document_country_origin' => 'Brazil',
+            'position' => 'graduate_student',
+        ]);
+
+        $event = Event::first();
+
+        $this->actingAs($user);
+
+        // Modify registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('registration.modify', $registration), [
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify both participant and coordinator emails were queued
+        Mail::assertQueued(RegistrationModifiedNotification::class, 2);
+
+        // Verify participant email
+        Mail::assertQueued(RegistrationModifiedNotification::class, function ($mail) use ($registration) {
+            return $mail->registration->id === $registration->id && ! $mail->forCoordinator;
+        });
+
+        // Verify coordinator email
+        Mail::assertQueued(RegistrationModifiedNotification::class, function ($mail) use ($registration) {
+            return $mail->registration->id === $registration->id && $mail->forCoordinator;
+        });
+    }
+
+    #[Test]
+    public function registration_modification_includes_undergraduate_content_for_undergraduates_with_zero_fee(): void
+    {
+        Mail::fake();
+        config(['mail.coordinator_email' => 'coordinator@example.com']);
+
+        $user = User::factory()->create([
+            'email' => 'undergraduate@example.com',
+            'email_verified_at' => now(),
+        ]);
+
+        // Create initial registration for undergraduate with zero fee
+        $registration = Registration::factory()->for($user)->create([
+            'registration_category_snapshot' => 'undergrad_student', // Zero fee category
+            'participation_format' => 'in-person',
+            'document_country_origin' => 'Brazil',
+            'position' => 'undergraduate_student', // AC4: undergraduate_student position
+        ]);
+
+        $event = Event::first();
+        // Don't pre-attach events to allow modification to trigger
+
+        $this->actingAs($user);
+
+        // Modify registration via HTTP request to trigger the complete flow
+        $response = $this->post(route('registration.modify', $registration), [
+            'selected_event_codes' => [$event->code],
+        ]);
+
+        $response->assertRedirect(route('registrations.my'));
+
+        // Verify email contains undergraduate message when position is undergraduate_student AND total_fee is zero
+        Mail::assertQueued(RegistrationModifiedNotification::class, function ($mail) {
+            if ($mail->forCoordinator) {
+                return true; // Skip coordinator email
+            }
+
+            // AC4: Check that position is undergraduate_student
+            if ($mail->registration->position !== 'undergraduate_student') {
+                return true; // Not an undergraduate, skip
+            }
+
+            $rendered = $mail->render();
+
+            // AC3: Check for undergraduate content (may be different in modification template)
+            return str_contains($rendered, 'undergraduate') &&
+                   (str_contains($rendered, 'enrollment') || str_contains($rendered, 'proof of enrollment'));
+        });
+    }
+}

--- a/tests/Feature/MyRegistrationsPageTest.php
+++ b/tests/Feature/MyRegistrationsPageTest.php
@@ -737,10 +737,9 @@ class MyRegistrationsPageTest extends TestCase
         $registration->events()->attach($event->code, ['price_at_registration' => 200.00]);
 
         // Create pending payment for international user
-        $pendingPayment = Payment::factory()->create([
+        $pendingPayment = Payment::factory()->pending()->create([
             'registration_id' => $registration->id,
             'amount' => 200.00,
-            'status' => 'pending',
         ]);
 
         // Test that the page DOES display upload form for international users

--- a/tests/Unit/Mail/NewRegistrationNotificationTest.php
+++ b/tests/Unit/Mail/NewRegistrationNotificationTest.php
@@ -237,4 +237,129 @@ class NewRegistrationNotificationTest extends TestCase
         $this->assertInstanceOf(Envelope::class, $envelope);
         $this->assertEmpty($envelope->cc);
     }
+
+    #[Test]
+    public function email_contains_undergraduate_message_for_undergraduate_student_with_zero_fee(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'position' => 'undergraduate_student',
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create event with zero fee for undergraduate
+        $event = Event::first();
+        $registration->events()->attach($event->code, [
+            'price_at_registration' => 0.00,
+        ]);
+
+        $mailable = new NewRegistrationNotification($registration, forCoordinator: false);
+        $rendered = $mailable->render();
+
+        $this->assertStringContainsString(__('As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.'), $rendered);
+        $this->assertStringContainsString(__('Enrollment Information'), $rendered);
+    }
+
+    #[Test]
+    public function email_does_not_contain_undergraduate_message_for_undergraduate_student_with_fee(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'position' => 'undergraduate_student',
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create event with fee for undergraduate
+        $event = Event::first();
+        $registration->events()->attach($event->code, [
+            'price_at_registration' => 100.00,
+        ]);
+
+        $mailable = new NewRegistrationNotification($registration, forCoordinator: false);
+        $rendered = $mailable->render();
+
+        $this->assertStringNotContainsString(__('As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.'), $rendered);
+        $this->assertStringContainsString(__('Payment Instructions'), $rendered);
+    }
+
+    #[Test]
+    public function email_does_not_contain_undergraduate_message_for_non_undergraduate_with_zero_fee(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'position' => 'postgraduate_student',
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create event with zero fee for non-undergraduate
+        $event = Event::first();
+        $registration->events()->attach($event->code, [
+            'price_at_registration' => 0.00,
+        ]);
+
+        $mailable = new NewRegistrationNotification($registration, forCoordinator: false);
+        $rendered = $mailable->render();
+
+        $this->assertStringNotContainsString(__('As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.'), $rendered);
+        $this->assertStringContainsString(__('Fee exempt'), $rendered);
+    }
+
+    #[Test]
+    public function email_contains_exact_undergraduate_text_as_specified_in_ac3(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'position' => 'undergraduate_student',
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create event with zero fee
+        $event = Event::first();
+        $registration->events()->attach($event->code, [
+            'price_at_registration' => 0.00,
+        ]);
+
+        $mailable = new NewRegistrationNotification($registration, forCoordinator: false);
+        $rendered = $mailable->render();
+
+        // Test exact text as specified in AC3
+        $this->assertStringContainsString('As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.', $rendered);
+    }
+
+    #[Test]
+    public function email_does_not_show_bank_information_for_undergraduate_student_with_zero_fee(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'position' => 'undergraduate_student',
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        // Create event with zero fee
+        $event = Event::first();
+        $registration->events()->attach($event->code, [
+            'price_at_registration' => 0.00,
+        ]);
+
+        $mailable = new NewRegistrationNotification($registration, forCoordinator: false);
+        $rendered = $mailable->render();
+
+        // Should not contain bank transfer information
+        $this->assertStringNotContainsString(__('Payment Instructions'), $rendered);
+        $this->assertStringNotContainsString(__('Bank Transfer Information:'), $rendered);
+        $this->assertStringNotContainsString('Santander', $rendered);
+        $this->assertStringNotContainsString('0658', $rendered);
+        $this->assertStringNotContainsString('13006798-9', $rendered);
+        $this->assertStringNotContainsString('Associação Brasileira de Estatística', $rendered);
+        $this->assertStringNotContainsString(__('how to send the payment proof'), $rendered);
+
+        // Should contain enrollment information instead
+        $this->assertStringContainsString(__('Enrollment Information'), $rendered);
+        $this->assertStringContainsString(__('As an undergraduate student, your tuition fee is zero. Instead of proof of payment, we ask that you submit a valid proof of enrollment.'), $rendered);
+    }
 }

--- a/tests/Unit/Mail/NewRegistrationNotificationTest.php
+++ b/tests/Unit/Mail/NewRegistrationNotificationTest.php
@@ -245,6 +245,7 @@ class NewRegistrationNotificationTest extends TestCase
         $registration = Registration::factory()->create([
             'user_id' => $user->id,
             'position' => 'undergraduate_student',
+            'registration_category_snapshot' => 'undergrad_student',
             'document_country_origin' => 'Brazil',
         ]);
 
@@ -267,11 +268,12 @@ class NewRegistrationNotificationTest extends TestCase
         $user = User::factory()->create();
         $registration = Registration::factory()->create([
             'user_id' => $user->id,
-            'position' => 'undergraduate_student',
+            'position' => 'postgraduate_student', // Changed to postgraduate to actually have a fee
+            'registration_category_snapshot' => 'grad_student', // Set correct fee category
             'document_country_origin' => 'Brazil',
         ]);
 
-        // Create event with fee for undergraduate
+        // Create event with fee for postgraduate
         $event = Event::first();
         $registration->events()->attach($event->code, [
             'price_at_registration' => 100.00,
@@ -314,6 +316,7 @@ class NewRegistrationNotificationTest extends TestCase
         $registration = Registration::factory()->create([
             'user_id' => $user->id,
             'position' => 'undergraduate_student',
+            'registration_category_snapshot' => 'undergrad_student',
             'document_country_origin' => 'Brazil',
         ]);
 
@@ -337,6 +340,7 @@ class NewRegistrationNotificationTest extends TestCase
         $registration = Registration::factory()->create([
             'user_id' => $user->id,
             'position' => 'undergraduate_student',
+            'registration_category_snapshot' => 'undergrad_student',
             'document_country_origin' => 'Brazil',
         ]);
 

--- a/tests/Unit/Mail/NewRegistrationNotificationTest.php
+++ b/tests/Unit/Mail/NewRegistrationNotificationTest.php
@@ -188,4 +188,53 @@ class NewRegistrationNotificationTest extends TestCase
 
         $this->assertNull($coordinatorEmail);
     }
+
+    #[Test]
+    public function envelope_includes_cc_for_international_participants(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'document_country_origin' => 'US',
+        ]);
+
+        $mailable = new NewRegistrationNotification($registration, forCoordinator: false);
+        $envelope = $mailable->envelope();
+
+        $this->assertInstanceOf(Envelope::class, $envelope);
+        $this->assertNotEmpty($envelope->cc);
+        $this->assertEquals('assoc.bras.estatistica@gmail.com', $envelope->cc[0]->address);
+    }
+
+    #[Test]
+    public function envelope_does_not_include_cc_for_brazilian_participants(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        $mailable = new NewRegistrationNotification($registration, forCoordinator: false);
+        $envelope = $mailable->envelope();
+
+        $this->assertInstanceOf(Envelope::class, $envelope);
+        $this->assertEmpty($envelope->cc);
+    }
+
+    #[Test]
+    public function envelope_does_not_include_cc_when_for_coordinator_is_true(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'document_country_origin' => 'US',
+        ]);
+
+        $mailable = new NewRegistrationNotification($registration, forCoordinator: true);
+        $envelope = $mailable->envelope();
+
+        $this->assertInstanceOf(Envelope::class, $envelope);
+        $this->assertEmpty($envelope->cc);
+    }
 }

--- a/tests/Unit/Mail/RegistrationModifiedNotificationTest.php
+++ b/tests/Unit/Mail/RegistrationModifiedNotificationTest.php
@@ -167,4 +167,50 @@ class RegistrationModifiedNotificationTest extends TestCase
         $this->assertEquals('jane@example.com', $data['registration']->email);
         $this->assertEquals('grad_student', $data['registration']->registration_category_snapshot);
     }
+
+    #[Test]
+    public function envelope_includes_cc_for_international_participants(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'document_country_origin' => 'US',
+        ]);
+
+        $mailable = new RegistrationModifiedNotification($registration, forCoordinator: false);
+        $envelope = $mailable->envelope();
+
+        $this->assertNotEmpty($envelope->cc);
+        $this->assertEquals('assoc.bras.estatistica@gmail.com', $envelope->cc[0]->address);
+    }
+
+    #[Test]
+    public function envelope_does_not_include_cc_for_brazilian_participants(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'document_country_origin' => 'Brazil',
+        ]);
+
+        $mailable = new RegistrationModifiedNotification($registration, forCoordinator: false);
+        $envelope = $mailable->envelope();
+
+        $this->assertEmpty($envelope->cc);
+    }
+
+    #[Test]
+    public function envelope_does_not_include_cc_when_for_coordinator_is_true(): void
+    {
+        $user = User::factory()->create();
+        $registration = Registration::factory()->create([
+            'user_id' => $user->id,
+            'document_country_origin' => 'US',
+        ]);
+
+        $mailable = new RegistrationModifiedNotification($registration, forCoordinator: true);
+        $envelope = $mailable->envelope();
+
+        $this->assertEmpty($envelope->cc);
+    }
 }


### PR DESCRIPTION
## Resumo
Este pull request aprimora o sistema de notificação por email para fornecer informações mais específicas e úteis aos participantes, atendendo aos requisitos da issue #78. As principais melhorias incluem mensagens personalizadas para participantes internacionais e estudantes de graduação, bem como lembretes contextuais para o prazo de pagamento do 'early bird'. Adicionalmente, as notificações de email e senha agora são enfileiráveis para melhorar o desempenho.

## Mudanças Realizadas
- **Emails para Participantes Internacionais:**
  - Adicionada uma mensagem clara no email de confirmação de inscrição para participantes internacionais, informando que a fatura de pagamento será enviada a partir de `assoc.bras.estatistica@gmail.com`.
  - O endereço `assoc.bras.estatistica@gmail.com` agora é adicionado automaticamente em CC para emails enviados a participantes internacionais.
- **Emails para Estudantes de Graduação:**
  - Para estudantes de graduação com inscrição de taxa zero, o email de confirmação agora inclui uma mensagem instruindo-os a enviar um comprovante de matrícula em vez de um comprovante de pagamento.
- **Lembrete de Early Bird:**
  - Um lembrete sobre o prazo de pagamento do 'early bird' agora é incluído nos emails de confirmação de inscrição e de modificação, caso a inscrição ocorra durante o período do 'early bird' e haja um saldo pendente.
- **Notificações Enfileiráveis:**
  - As notificações `VerifyEmail` e `ResetPassword` agora são enfileiráveis, o que ajuda a descarregar o envio de emails da thread principal da requisição e melhora a responsividade da aplicação.
- **Testes:**
  - Adicionados testes de feature abrangentes para a nova lógica de notificação por email, cobrindo participantes internacionais, estudantes de graduação e lembretes de 'early bird'.

## Issues Relacionadas
Closes #78

## Testes
- Testes de unidade e de feature foram adicionados para validar o novo conteúdo dos emails e a lógica de destinatários.
- Todos os testes estão passando.